### PR TITLE
Allow targeting newer ES version when using JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## __WORK_IN_PROGRESS__
+* (AlCalzone) Allow targeting newer ES version when using JS (fixes #43)
+
 ## v1.4.0 (2018-12-27)
 * (AlCalzone) Add selection for adapter category (fixes #2)
 * (AlCalzone) Move ESLint to non-dev dependencies (fixes #44)

--- a/build/lib/questions.js
+++ b/build/lib/questions.js
@@ -127,6 +127,16 @@ exports.questionsAndText = [
             "TypeScript",
         ],
     },
+    {
+        condition: { name: "language", value: "JavaScript" },
+        type: "select",
+        name: "ecmaVersion",
+        message: `Do you need async functions or String.pad{Start,End}`,
+        choices: [
+            { message: "yes", value: 8 },
+            { message: "no", value: 6 },
+        ],
+    },
     styledMultiselect({
         condition: { name: "language", value: "JavaScript" },
         name: "tools",

--- a/build/templates/_eslintrc.json.js
+++ b/build/templates/_eslintrc.json.js
@@ -1,8 +1,10 @@
 "use strict";
+const JSON5 = require("json5");
 const templateFunction = answers => {
     const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
     if (!useESLint)
         return;
+    const ecmaVersion = answers.ecmaVersion || 2015;
     const template = `
 {
     "env": {
@@ -34,10 +36,15 @@ const templateFunction = answers => {
             "error",
             "always"
         ]
-    }
+	},
+	${ecmaVersion > 2015 ? (`
+		"parserOptions": {
+			"ecmaVersion": ${ecmaVersion}
+		}
+	`) : ""}
 }
 `;
-    return template.trim();
+    return JSON.stringify(JSON5.parse(template), null, 4);
 };
 templateFunction.customPath = ".eslintrc.json";
 module.exports = templateFunction;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -122,6 +122,7 @@ describe("adapter creation =>", () => {
 				const answers: Answers = {
 					...baseAnswers,
 					language: "JavaScript",
+					ecmaVersion: 2015,
 					tools: ["ESLint", "type checking"],
 					indentation: "Space (4)",
 					quotes: "single",
@@ -203,6 +204,20 @@ describe("adapter creation =>", () => {
 					"type_visualization-icons",
 					answers,
 					file => file.name === "io-package.json",
+				);
+			});
+
+			it(`JS with ES2017`, async () => {
+				const answers: Answers = {
+					...baseAnswers,
+					language: "JavaScript",
+					ecmaVersion: 2017,
+					tools: ["ESLint", "type checking"],
+				};
+				await expectSuccess(
+					"JS_ES2017",
+					answers,
+					file => file.name === ".eslintrc.json",
 				);
 			});
 		});

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -149,6 +149,16 @@ export const questionsAndText: (Question | string)[] = [
 			"TypeScript",
 		],
 	},
+	{
+		condition: { name: "language", value: "JavaScript" },
+		type: "select",
+		name: "ecmaVersion",
+		message: `Do you need async functions or String.pad{Start,End}`,
+		choices: [
+			{ message: "yes", value: 8 },
+			{ message: "no", value: 6 },
+		],
+	},
 	styledMultiselect({
 		condition: { name: "language", value: "JavaScript" },
 		name: "tools",
@@ -286,6 +296,7 @@ export interface Answers {
 	language?: "JavaScript" | "TypeScript";
 	features: ("adapter" | "vis")[];
 	tools?: ("ESLint" | "TSLint" | "type checking" | "code coverage")[];
+	ecmaVersion?: 2015 | 2017;
 	title?: string;
 	license: { id: string, name: string, text: string };
 	type: string;

--- a/src/templates/_eslintrc.json.ts
+++ b/src/templates/_eslintrc.json.ts
@@ -1,10 +1,12 @@
+import * as JSON5 from "json5";
 import { TemplateFunction } from "../lib/createAdapter";
-import { Answers } from "../lib/questions";
 
 const templateFunction: TemplateFunction = answers => {
 
 	const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
 	if (!useESLint) return;
+
+	const ecmaVersion = answers.ecmaVersion || 2015;
 
 	const template = `
 {
@@ -37,10 +39,15 @@ const templateFunction: TemplateFunction = answers => {
             "error",
             "always"
         ]
-    }
+	},
+	${ecmaVersion > 2015 ? (`
+		"parserOptions": {
+			"ecmaVersion": ${ecmaVersion}
+		}
+	`) : ""}
 }
 `;
-	return template.trim();
+	return JSON.stringify(JSON5.parse(template), null, 4);
 };
 
 templateFunction.customPath = ".eslintrc.json";

--- a/test/baselines/JS_ES2017/.eslintrc.json
+++ b/test/baselines/JS_ES2017/.eslintrc.json
@@ -1,0 +1,35 @@
+{
+	"env": {
+		"es6": true,
+		"node": true,
+		"mocha": true
+	},
+	"extends": "eslint:recommended",
+	"rules": {
+		"indent": [
+			"error",
+			"tab",
+			{
+				"SwitchCase": 1
+			}
+		],
+		"no-console": "off",
+		"no-var": "error",
+		"prefer-const": "error",
+		"quotes": [
+			"error",
+			"double",
+			{
+				"avoidEscape": true,
+				"allowTemplateLiterals": true
+			}
+		],
+		"semi": [
+			"error",
+			"always"
+		]
+	},
+	"parserOptions": {
+		"ecmaVersion": 2017
+	}
+}

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -32,7 +32,7 @@
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^5.10.0",
+    "eslint": "^5.11.1",
     "gulp": "^4.0.0",
     "mocha": "^5.2.0",
     "proxyquire": "^2.1.0",


### PR DESCRIPTION
**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [x] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build` and include those artifacts aswell
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
Fixes #43 by adding the correct section to `.eslintrc.json`
