### PR TITLE
 Bind event handlers in the ES6 templates to the class instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## __WORK IN PROGRESS__
 * (AlCalzone) Add the possibility to specify keywords (fixes #3)
+* (AlCalzone) Bind event handlers in the ES6 templates to the class instance
 
 ## 1.9.0 (2019-02-14)
 * (AlCalzone) Add the ability to pin package versions in the template `package.json`

--- a/templates/main.es6.js.ts
+++ b/templates/main.es6.js.ts
@@ -35,11 +35,11 @@ class ${className} extends utils.Adapter {
 			...options,
 			name: "${answers.adapterName}",
 		});
-		this.on("ready", this.onReady);
-		this.on("objectChange", this.onObjectChange);
-		this.on("stateChange", this.onStateChange);
-		// this.on("message", this.onMessage);
-		this.on("unload", this.onUnload);
+		this.on("ready", this.onReady.bind(this));
+		this.on("objectChange", this.onObjectChange.bind(this));
+		this.on("stateChange", this.onStateChange.bind(this));
+		// this.on("message", this.onMessage.bind(this));
+		this.on("unload", this.onUnload.bind(this));
 	}
 
 	/**

--- a/templates/src/main.es6.ts
+++ b/templates/src/main.es6.ts
@@ -44,11 +44,11 @@ class ${className} extends utils.Adapter {
 			...options,
 			name: "${answers.adapterName}",
 		});
-		this.on("ready", this.onReady);
-		this.on("objectChange", this.onObjectChange);
-		this.on("stateChange", this.onStateChange);
-		// this.on("message", this.onMessage);
-		this.on("unload", this.onUnload);
+		this.on("ready", this.onReady.bind(this));
+		this.on("objectChange", this.onObjectChange.bind(this));
+		this.on("stateChange", this.onStateChange.bind(this));
+		// this.on("message", this.onMessage.bind(this));
+		this.on("unload", this.onUnload.bind(this));
 	}
 
 	/**

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -21,11 +21,11 @@ class TestAdapter extends utils.Adapter {
             ...options,
             name: 'test-adapter',
         });
-        this.on('ready', this.onReady);
-        this.on('objectChange', this.onObjectChange);
-        this.on('stateChange', this.onStateChange);
-        // this.on("message", this.onMessage);
-        this.on('unload', this.onUnload);
+        this.on('ready', this.onReady.bind(this));
+        this.on('objectChange', this.onObjectChange.bind(this));
+        this.on('stateChange', this.onStateChange.bind(this));
+        // this.on("message", this.onMessage.bind(this));
+        this.on('unload', this.onUnload.bind(this));
     }
 
     /**

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -22,12 +22,12 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.2",
+    "@iobroker/testing": "^1.1.3",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^10.12.26",
+    "@types/node": "^10.12.27",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.6",
     "@types/sinon-chai": "^3.2.2",
@@ -36,7 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.14.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.0",
+    "mocha": "^6.0.1",
     "proxyquire": "^2.1.0",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0"

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -22,12 +22,12 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.2",
+    "@iobroker/testing": "^1.1.3",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^10.12.26",
+    "@types/node": "^10.12.27",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.6",
     "@types/sinon-chai": "^3.2.2",
@@ -36,7 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.14.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.0",
+    "mocha": "^6.0.1",
     "proxyquire": "^2.1.0",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0"

--- a/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/package.json
@@ -22,12 +22,12 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.2",
+    "@iobroker/testing": "^1.1.3",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^10.12.26",
+    "@types/node": "^10.12.27",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.6",
     "@types/sinon-chai": "^3.2.2",
@@ -35,15 +35,15 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.0",
+    "mocha": "^6.0.1",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
-    "tslint": "^5.12.1",
-    "typescript": "^3.3.3"
+    "tslint": "^5.13.0",
+    "typescript": "^3.3.3333"
   },
   "main": "build/main.js",
   "scripts": {

--- a/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -30,11 +30,11 @@ class TestAdapter extends utils.Adapter {
 			...options,
 			name: "test-adapter",
 		});
-		this.on("ready", this.onReady);
-		this.on("objectChange", this.onObjectChange);
-		this.on("stateChange", this.onStateChange);
-		// this.on("message", this.onMessage);
-		this.on("unload", this.onUnload);
+		this.on("ready", this.onReady.bind(this));
+		this.on("objectChange", this.onObjectChange.bind(this));
+		this.on("stateChange", this.onStateChange.bind(this));
+		// this.on("message", this.onMessage.bind(this));
+		this.on("unload", this.onUnload.bind(this));
 	}
 
 	/**

--- a/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/package.json
@@ -22,12 +22,12 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.2",
+    "@iobroker/testing": "^1.1.3",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^10.12.26",
+    "@types/node": "^10.12.27",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.6",
     "@types/sinon-chai": "^3.2.2",
@@ -35,15 +35,15 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.0",
+    "mocha": "^6.0.1",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
-    "tslint": "^5.12.1",
-    "typescript": "^3.3.3"
+    "tslint": "^5.13.0",
+    "typescript": "^3.3.3333"
   },
   "main": "build/main.js",
   "scripts": {

--- a/test/baselines/keywords/package.json
+++ b/test/baselines/keywords/package.json
@@ -23,12 +23,12 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.2",
+    "@iobroker/testing": "^1.1.3",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^10.12.26",
+    "@types/node": "^10.12.27",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.6",
     "@types/sinon-chai": "^3.2.2",
@@ -36,15 +36,15 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.0",
+    "mocha": "^6.0.1",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.5.10",
     "ts-node": "^8.0.2",
-    "tslint": "^5.12.1",
-    "typescript": "^3.3.3"
+    "tslint": "^5.13.0",
+    "typescript": "^3.3.3333"
   },
   "main": "build/main.js",
   "scripts": {

--- a/test/baselines/vis_Widget/package.json
+++ b/test/baselines/vis_Widget/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@iobroker/testing": "^1.1.2",
+    "@iobroker/testing": "^1.1.3",
     "@types/gulp": "^4.0.5",
     "axios": "^0.18.0",
     "gulp": "^4.0.0"


### PR DESCRIPTION
**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [x] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] If you added a required option, also add it to the template creation (`travis/create_templates.ts`)
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
It can happen that the event handlers are invoked with the wrong `this` context. This PR ensures the handlers are always bound to the class instance.