### PR TITLE
 Enforce `js-controller >= 1.4.2` during installation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
-## 1.10.0 (2019-02-25)
+<!--
+	Placeholder for the next version:
+	## __WORK IN PROGRESS__
+	(at the beginning of a new line )
+-->
+
+## __WORK IN PROGRESS__
+* (AlCalzone) Enforce `js-controller >= 1.4.2` during installation
+
+## v1.10.0 (2019-02-25)
 * (AlCalzone) Add more unit tests
 * (AlCalzone) Add the possibility to specify keywords (fixes #3)
 * (AlCalzone) Bind event handlers in the ES6 templates to the class instance
 
-## 1.9.0 (2019-02-14)
+## v1.9.0 (2019-02-14)
 * (AlCalzone) Add the ability to pin package versions in the template `package.json`
 * (AlCalzone & bluefox) Automatically translate settings labels in words.js (fixes #98)
 * (AlCalzone & bluefox) Add the possibility to specify adapter config and generate options page (not on the CLI) (fixes #97)
@@ -23,21 +32,21 @@
 To use it, append `--yandex <yandex_api_key>` to the gulp command.
 * (AlCalzone) Add license to io-package.json (fixes #88)
 
-## 1.8.0 (2019-01-24)
+## v1.8.0 (2019-01-24)
 * (AlCalzone & jogibear9988) Add ES6 class support for the main file
 
-## 1.7.0 (2019-01-23)
+## v1.7.0 (2019-01-23)
 * (AlCalzone) Automatically create the template repo on release
 * (AlCalzone) Always create `gulpfile.js`, even in VIS-only templates (fixes #75)
 * (AlCalzone) Add `"compact": true` to `io-package.json` in adapter mode (fixes #47)
 
-## 1.6.3 (2019-01-22)
+## v1.6.3 (2019-01-22)
 * (AlCalzone) Use `files` in `package.json` instead of `.npmignore` to avoid excluding templates.
 
-## 1.6.1 (2019-01-19)
+## v1.6.1 (2019-01-19)
 * (AlCalzone) Fix "cannot find module `typescript`"
 
-## 1.6.0 (2019-01-17)
+## v1.6.0 (2019-01-17)
 * (AlCalzone) Allow choosing quote style in TypeScript (fixes #33)
 * (AlCalzone) Ensure JS files contain `"use strict";` (fixes #53)
 * (AlCalzone) Print the creator version in the main file header (fixes #52)
@@ -49,7 +58,7 @@ To use it, append `--yandex <yandex_api_key>` to the gulp command.
 * (ldittmar & AlCalzone) Support custom_m.html (fixes #61)
 * (ldittmar & AlCalzone) Support admin tab (fixes #14)
 
-## 1.5.0 (2019-01-07)
+## v1.5.0 (2019-01-07)
 * (AlCalzone) Allow targeting newer ES version when using JS (fixes #43)
 * (AlCalzone) Support compact mode (coming in JS-Controller 2.0) (fixes #47)
 

--- a/maintenance/release.ts
+++ b/maintenance/release.ts
@@ -38,9 +38,10 @@ const pack = require(packPath);
 const changelogPath = path.join(rootDir, "CHANGELOG.md");
 let changelog = fs.readFileSync(changelogPath, "utf8");
 const CHANGELOG_PLACEHOLDER = "## __WORK IN PROGRESS__";
+const CHANGELOG_PLACEHOLDER_REGEX = new RegExp("^" + CHANGELOG_PLACEHOLDER + "$", "gm");
 
 // check if the changelog contains exactly 1 occurence of the changelog placeholder
-switch ((changelog.match(new RegExp("^" + CHANGELOG_PLACEHOLDER + "$", "gm")) || []).length) {
+switch ((changelog.match(CHANGELOG_PLACEHOLDER_REGEX) || []).length) {
 	case 0:
 		fail(colors.red(
 			"Cannot continue, the changelog placeholder is missing from CHANGELOG.md!\n"
@@ -108,8 +109,8 @@ if (argv.dry) {
 	console.log(`updating CHANGELOG.md`);
 	const d = new Date();
 	changelog = changelog.replace(
-		CHANGELOG_PLACEHOLDER,
-		`## ${newVersion} (${d.getFullYear()}-${padStart("" + (d.getMonth() + 1), 2, "0")}-${padStart("" + d.getDate(), 2, "0")})`,
+		CHANGELOG_PLACEHOLDER_REGEX,
+		`## v${newVersion} (${d.getFullYear()}-${padStart("" + (d.getMonth() + 1), 2, "0")}-${padStart("" + d.getDate(), 2, "0")})`,
 	);
 	fs.writeFileSync(changelogPath, changelog, "utf8");
 

--- a/templates/io-package.json.ts
+++ b/templates/io-package.json.ts
@@ -96,6 +96,7 @@ export = (async answers => {
 		${supportCustom ? `"supportCustoms": true,` : ""}
 		"dependencies": [
 			${isAdapter ? `{ "admin": ">=3.0.0" },` : ""}
+			${isAdapter ? `{ "js-controller": ">=1.4.2" },` : ""}
 			${isWidget ? `"vis",` : ""}
 		],
 	},

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/io-package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/io-package.json
@@ -65,6 +65,9 @@
         "dependencies": [
             {
                 "admin": ">=3.0.0"
+            },
+            {
+                "js-controller": ">=1.4.2"
             }
         ]
     },

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -22,7 +22,7 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.3",
+    "@iobroker/testing": "^1.1.4",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
@@ -36,7 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.14.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.1",
+    "mocha": "^6.0.2",
     "proxyquire": "^2.1.0",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0"

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/io-package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/io-package.json
@@ -65,6 +65,9 @@
         "dependencies": [
             {
                 "admin": ">=3.0.0"
+            },
+            {
+                "js-controller": ">=1.4.2"
             }
         ]
     },

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -22,7 +22,7 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.3",
+    "@iobroker/testing": "^1.1.4",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
@@ -36,7 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.14.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.1",
+    "mocha": "^6.0.2",
     "proxyquire": "^2.1.0",
     "sinon": "^7.2.4",
     "sinon-chai": "^3.3.0"

--- a/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/io-package.json
+++ b/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/package.json
@@ -22,7 +22,7 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.3",
+    "@iobroker/testing": "^1.1.4",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
@@ -35,7 +35,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.1",
+    "mocha": "^6.0.2",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.2.4",

--- a/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_TSLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/io-package.json
+++ b/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/io-package.json
@@ -84,6 +84,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/package.json
@@ -22,7 +22,7 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.3",
+    "@iobroker/testing": "^1.1.4",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
@@ -35,7 +35,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.1",
+    "mocha": "^6.0.2",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.2.4",

--- a/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_TSLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/connectionIndicator_yes/io-package.json
+++ b/test/baselines/connectionIndicator_yes/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/customAdapterSettings/io-package.json
+++ b/test/baselines/customAdapterSettings/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.9.0
+ * Created with @iobroker/create-adapter v1.10.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/description_empty_1/io-package.json
+++ b/test/baselines/description_empty_1/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/description_empty_2/io-package.json
+++ b/test/baselines/description_empty_2/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/description_valid/io-package.json
+++ b/test/baselines/description_valid/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/keywords/io-package.json
+++ b/test/baselines/keywords/io-package.json
@@ -66,6 +66,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/keywords/package.json
+++ b/test/baselines/keywords/package.json
@@ -23,7 +23,7 @@
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {
-    "@iobroker/testing": "^1.1.3",
+    "@iobroker/testing": "^1.1.4",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
     "@types/gulp": "^4.0.5",
@@ -36,7 +36,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.0",
-    "mocha": "^6.0.1",
+    "mocha": "^6.0.2",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.2.4",

--- a/test/baselines/startMode_schedule/io-package.json
+++ b/test/baselines/startMode_schedule/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/type_storage/io-package.json
+++ b/test/baselines/type_storage/io-package.json
@@ -65,6 +65,9 @@
 		"dependencies": [
 			{
 				"admin": ">=3.0.0"
+			},
+			{
+				"js-controller": ">=1.4.2"
 			}
 		]
 	},

--- a/test/baselines/vis_Widget/package.json
+++ b/test/baselines/vis_Widget/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@iobroker/testing": "^1.1.3",
+    "@iobroker/testing": "^1.1.4",
     "@types/gulp": "^4.0.5",
     "axios": "^0.18.0",
     "gulp": "^4.0.0"


### PR DESCRIPTION
**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] If you added a required option, also add it to the template creation (`travis/create_templates.ts`)
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
Since many new adapters are using the new `xxxAsync` methods only present in JS-C 1.4.2 and newer, this version range is now enforced during the adapter installation.
