### PR TITLE
Add Prettier as a tool option in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 	(at the beginning of a new line )
 -->
 
+## __WORK IN PROGRESS__
+* (AlCalzone) Add the option to use Prettier as a formatter in TypeScript (#164)  
+**Note:** This option also enables different auto-formatting settings in VSCode
+
 ## v1.13.0 (2019-05-06)
 * (AlCalzone) Remove extraneous quotes from "initial commit" (#159)
 * (AlCalzone) Switch TypeScript templates to ESLint (#158)

--- a/src/lib/actionsAndTransformers.ts
+++ b/src/lib/actionsAndTransformers.ts
@@ -1,5 +1,6 @@
 import { yellow } from "ansi-colors";
 import { fetchPackageVersion } from "./packageVersions";
+import { Answers } from "./questions";
 
 const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
@@ -77,6 +78,15 @@ export async function checkAuthorName(name?: string): Promise<CheckResult> {
 export async function checkEmail(email: string): Promise<CheckResult> {
 	if (!emailRegex.test(email)) {
 		return "Please enter a valid email address!";
+	}
+	return true;
+}
+
+export async function checkTypeScriptTools(
+	tools: Exclude<Answers["tools"], undefined>,
+): Promise<CheckResult> {
+	if (tools.indexOf("Prettier") > -1 && tools.indexOf("ESLint") === -1) {
+		return "ESLint must be selected to use Prettier!";
 	}
 	return true;
 }

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -8,6 +8,7 @@ import {
 	checkMinSelections,
 	CheckResult,
 	checkTitle,
+	checkTypeScriptTools,
 	transformAdapterName,
 	transformDescription,
 	transformKeywords,
@@ -358,8 +359,14 @@ export const questionsAndText: (Question | QuestionGroup | string)[] = [
 				initial: [0],
 				choices: [
 					{ message: "ESLint", hint: "(recommended)" },
+					{
+						message: "Prettier",
+						hint:
+							"(requires ESLint, enables automatic code formatting in VSCode)",
+					},
 					{ message: "code coverage" },
 				],
+				action: checkTypeScriptTools,
 			}),
 
 			// TODO: enable React (only TypeScript at the start)
@@ -523,7 +530,7 @@ export interface Answers {
 	language?: "JavaScript" | "TypeScript";
 	features: ("adapter" | "vis")[];
 	adminFeatures?: ("tab" | "custom")[];
-	tools?: ("ESLint" | "type checking" | "code coverage")[];
+	tools?: ("ESLint" | "Prettier" | "type checking" | "code coverage")[];
 	ecmaVersion?: 2015 | 2016 | 2017 | 2018 | 2019;
 	title?: string;
 	license?: { id: string; name: string; text: string };

--- a/templates/_eslintrc_typescript.js.ts
+++ b/templates/_eslintrc_typescript.js.ts
@@ -7,6 +7,7 @@ const templateFunction: TemplateFunction = answers => {
 
 	const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
 	if (!useESLint) return;
+	const usePrettier = answers.tools && answers.tools.indexOf("Prettier") > -1;
 
 	const template = `
 module.exports = {
@@ -18,10 +19,14 @@ module.exports = {
 	},
 	extends: [
 		"plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-	],
+${usePrettier ? (
+`		"prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+		"plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+`) : ""}	],
 	plugins: [],
 	rules: {
-		"indent": "off",
+${usePrettier ? "" : (
+`		"indent": "off",
 		"@typescript-eslint/indent": [
 			"error",
 			${answers.indentation === "Tab" ? `"tab"` : "4"},
@@ -29,7 +34,16 @@ module.exports = {
 				"SwitchCase": 1
 			}
 		],
-		"@typescript-eslint/no-parameter-properties": "off",
+		"quotes": [
+			"error",
+			"${typeof answers.quotes === "string" ? answers.quotes : "double"}",
+			{
+				"avoidEscape": true,
+				"allowTemplateLiterals": true
+			}
+		],
+`)
+}		"@typescript-eslint/no-parameter-properties": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-use-before-define": [
 			"error",
@@ -56,14 +70,6 @@ module.exports = {
 		"@typescript-eslint/no-object-literal-type-assertion": "off",
 		"@typescript-eslint/interface-name-prefix": "off",
 		"@typescript-eslint/no-non-null-assertion": "off", // This is necessary for Map.has()/get()!
-		"quotes": [
-			"error",
-			"${typeof answers.quotes === "string" ? answers.quotes : "double"}",
-			{
-				"avoidEscape": true,
-				"allowTemplateLiterals": true
-			}
-		],
 		"no-var": "error",
 		"prefer-const": "error",
 	},

--- a/templates/_prettierignore.ts
+++ b/templates/_prettierignore.ts
@@ -1,0 +1,18 @@
+import { TemplateFunction } from "../src/lib/createAdapter";
+
+const templateFunction: TemplateFunction = answers => {
+
+	const usePrettier = answers.tools && answers.tools.indexOf("Prettier") > -1;
+	if (!usePrettier) return;
+	const useTypeScript = answers.language === "TypeScript";
+
+	const template = `
+package.json
+package-lock.json
+${useTypeScript ? "build/" : ""}
+`;
+	return template.trim();
+};
+
+templateFunction.customPath = ".prettierignore";
+export = templateFunction;

--- a/templates/_prettierrc.js.ts
+++ b/templates/_prettierrc.js.ts
@@ -1,0 +1,28 @@
+import { TemplateFunction } from "../src/lib/createAdapter";
+
+const templateFunction: TemplateFunction = answers => {
+
+	const usePrettier = answers.tools && answers.tools.indexOf("Prettier") > -1;
+	if (!usePrettier) return;
+
+	// endOfLine could be made dependent on the current OS's line ending
+	// I need to think about it.
+	// However leaving it on "auto" causes linting to fail on CI servers
+	// when the adapter was developed on Windows
+	
+	const template = `
+module.exports = {
+	semi: true,
+	trailingComma: "all",
+	singleQuote: ${answers.quotes === "single"},
+	printWidth: 120,
+	useTabs: ${answers.indentation === "Tab"},
+	tabWidth: 4,
+	endOfLine: "lf",
+};
+`;
+	return template.trim();
+};
+
+templateFunction.customPath = ".prettierrc.js";
+export = templateFunction;

--- a/templates/_vscode/extensions.json.ts
+++ b/templates/_vscode/extensions.json.ts
@@ -1,0 +1,23 @@
+import * as JSON5 from "json5";
+import { TemplateFunction } from "../../src/lib/createAdapter";
+
+const templateFunction: TemplateFunction = answers => {
+
+	const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
+	const usePrettier = answers.tools && answers.tools.indexOf("Prettier") > -1;
+
+	if (!useESLint && !usePrettier) return;
+
+	const template = `
+{
+	"recommendations": [
+		${useESLint ? `"dbaeumer.vscode-eslint",` : ""}
+		${usePrettier ? `"esbenp.prettier-vscode",` : ""}
+	]
+}
+`;
+return JSON.stringify(JSON5.parse(template), null, 4);
+};
+
+templateFunction.customPath = ".vscode/extensions.json";
+export = templateFunction;

--- a/templates/_vscode/settings.json.ts
+++ b/templates/_vscode/settings.json.ts
@@ -1,0 +1,33 @@
+import * as JSON5 from "json5";
+import { TemplateFunction } from "../../src/lib/createAdapter";
+
+const templateFunction: TemplateFunction = answers => {
+
+	const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
+	const usePrettier = answers.tools && answers.tools.indexOf("Prettier") > -1;
+	const useTypeScript = answers.language === "TypeScript";
+
+	if (!useESLint && !usePrettier && !useTypeScript) return;
+
+	const template = `
+{
+${useTypeScript ? `"typescript.tsdk": "node_modules/typescript/lib",` : ""}
+${useESLint ? `"eslint.enable": true,` : ""}
+${usePrettier ? (`
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	${useTypeScript ? (`
+	"[typescript]": {
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": true
+		},
+	},
+	`) : ""}
+`) : ""}
+}
+`;
+return JSON.stringify(JSON5.parse(template), null, 4);
+};
+
+templateFunction.customPath = ".vscode/settings.json";
+export = templateFunction;

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -43,6 +43,10 @@ const templates: { name: string, templateFunction: TemplateFunction }[] = [
 	{ name: "_gitignore.ts", templateFunction: require("./_gitignore") },
 	{ name: "_issue_template/bug_report.md.ts", templateFunction: require("./_issue_template/bug_report.md") },
 	{ name: "_npmignore.ts", templateFunction: require("./_npmignore") },
+	{ name: "_prettierignore.ts", templateFunction: require("./_prettierignore") },
+	{ name: "_prettierrc.js.ts", templateFunction: require("./_prettierrc.js") },
 	{ name: "_travis.yml.ts", templateFunction: require("./_travis.yml") },
+	{ name: "_vscode/extensions.json.ts", templateFunction: require("./_vscode/extensions.json") },
+	{ name: "_vscode/settings.json.ts", templateFunction: require("./_vscode/settings.json") },
 ];
 export = templates;

--- a/templates/package.json.ts
+++ b/templates/package.json.ts
@@ -10,6 +10,7 @@ const templateFunction: TemplateFunction = async answers => {
 	const isWidget = answers.features.indexOf("vis") > -1;
 	const useTypeScript = answers.language === "TypeScript";
 	const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
+	const usePrettier = answers.tools && answers.tools.indexOf("Prettier") > -1;
 	const useNyc = answers.tools && answers.tools.indexOf("code coverage") > -1;
 
 	const dependencyPromises = ([] as string[])
@@ -58,6 +59,11 @@ const templateFunction: TemplateFunction = async answers => {
 		.concat((useESLint && useTypeScript) ? [
 			"@typescript-eslint/eslint-plugin",
 			"@typescript-eslint/parser",
+		] : [])
+		.concat((useESLint && usePrettier) ? [
+			"eslint-config-prettier",
+			"eslint-plugin-prettier",
+			"prettier",
 		] : [])
 		.concat(useNyc ? ["nyc"] : [])
 		.sort()

--- a/test/baselines/TS_Prettier/.eslintrc.js
+++ b/test/baselines/TS_Prettier/.eslintrc.js
@@ -7,25 +7,11 @@ module.exports = {
 	},
 	extends: [
 		"plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+		"prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+		"plugin:prettier/recommended", // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
 	],
 	plugins: [],
 	rules: {
-		"indent": "off",
-		"@typescript-eslint/indent": [
-			"error",
-			"tab",
-			{
-				"SwitchCase": 1
-			}
-		],
-		"quotes": [
-			"error",
-			"double",
-			{
-				"avoidEscape": true,
-				"allowTemplateLiterals": true
-			}
-		],
 		"@typescript-eslint/no-parameter-properties": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-use-before-define": [

--- a/test/baselines/TS_Prettier/.prettierignore
+++ b/test/baselines/TS_Prettier/.prettierignore
@@ -1,0 +1,3 @@
+package.json
+package-lock.json
+build/

--- a/test/baselines/TS_Prettier/.prettierrc.js
+++ b/test/baselines/TS_Prettier/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+	semi: true,
+	trailingComma: "all",
+	singleQuote: false,
+	printWidth: 120,
+	useTabs: true,
+	tabWidth: 4,
+	endOfLine: "lf",
+};

--- a/test/baselines/TS_Prettier/.vscode/extensions.json
+++ b/test/baselines/TS_Prettier/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
+	]
+}

--- a/test/baselines/TS_Prettier/.vscode/settings.json
+++ b/test/baselines/TS_Prettier/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"eslint.enable": true,
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[typescript]": {
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": true
+		}
+	}
+}

--- a/test/baselines/TS_Prettier/package.json
+++ b/test/baselines/TS_Prettier/package.json
@@ -7,7 +7,7 @@
     "email": "al@calzo.ne"
   },
   "homepage": "https://github.com/AlCalzone/ioBroker.test-adapter",
-  "license": "LGPL-3.0",
+  "license": "MIT",
   "keywords": [
     "ioBroker",
     "template",
@@ -31,24 +31,38 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.11",
     "@types/sinon-chai": "^3.2.2",
+    "@typescript-eslint/eslint-plugin": "^1.7.0",
+    "@typescript-eslint/parser": "^1.7.0",
     "axios": "^0.18.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "gulp": "^4.0.2",
     "mocha": "^6.1.4",
+    "prettier": "^1.17.0",
     "proxyquire": "^2.1.0",
+    "rimraf": "^2.6.3",
     "sinon": "^7.3.2",
-    "sinon-chai": "^3.3.0"
+    "sinon-chai": "^3.3.0",
+    "source-map-support": "^0.5.12",
+    "ts-node": "^8.1.0",
+    "typescript": "^3.4.5"
   },
-  "main": "main.js",
+  "main": "build/main.js",
   "scripts": {
-    "test:js": "mocha --opts test/mocha.custom.opts",
+    "prebuild": "rimraf ./build",
+    "build:ts": "tsc -p tsconfig.build.json",
+    "build": "npm run build:ts",
+    "watch:ts": "tsc -p tsconfig.build.json --watch",
+    "watch": "npm run watch:ts",
+    "test:ts": "mocha --opts test/mocha.custom.opts",
     "test:package": "mocha test/package --exit",
     "test:unit": "mocha test/unit --exit",
     "test:integration": "mocha test/integration --exit",
-    "test": "npm run test:js && npm run test:package",
-    "lint": "eslint"
+    "test": "npm run test:ts && npm run test:package",
+    "lint": "eslint --ext .ts src"
   },
   "bugs": {
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter/issues"

--- a/test/baselines/TS_SingleQuotes/.eslintrc.js
+++ b/test/baselines/TS_SingleQuotes/.eslintrc.js
@@ -1,0 +1,67 @@
+module.exports = {
+	parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+	parserOptions: {
+		ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+		sourceType: 'module', // Allows for the use of imports
+		project: './tsconfig.json',
+	},
+	extends: [
+		'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+	],
+	plugins: [],
+	rules: {
+		'indent': 'off',
+		'@typescript-eslint/indent': [
+			'error',
+			'tab',
+			{
+				'SwitchCase': 1
+			}
+		],
+		'quotes': [
+			'error',
+			'single',
+			{
+				'avoidEscape': true,
+				'allowTemplateLiterals': true
+			}
+		],
+		'@typescript-eslint/no-parameter-properties': 'off',
+		'@typescript-eslint/no-explicit-any': 'off',
+		'@typescript-eslint/no-use-before-define': [
+			'error',
+			{
+				functions: false,
+				typedefs: false,
+				classes: false,
+			},
+		],
+		'@typescript-eslint/no-unused-vars': [
+			'error',
+			{
+				ignoreRestSiblings: true,
+				argsIgnorePattern: '^_',
+			},
+		],
+		'@typescript-eslint/explicit-function-return-type': [
+			'warn',
+			{
+				allowExpressions: true,
+				allowTypedFunctionExpressions: true,
+			},
+		],
+		'@typescript-eslint/no-object-literal-type-assertion': 'off',
+		'@typescript-eslint/interface-name-prefix': 'off',
+		'@typescript-eslint/no-non-null-assertion': 'off', // This is necessary for Map.has()/get()!
+		'no-var': 'error',
+		'prefer-const': 'error',
+	},
+	overrides: [
+		{
+			files: ['*.test.ts'],
+			rules: {
+				'@typescript-eslint/explicit-function-return-type': 'off',
+			},
+		},
+	],
+};

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/extensions.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/settings.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": true
+}

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/extensions.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/settings.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": true
+}

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "sinon": "^7.3.2",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.vscode/extensions.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"dbaeumer.vscode-eslint"
+	]
+}

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.vscode/settings.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"eslint.enable": true
+}

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.eslintrc.js
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.eslintrc.js
@@ -18,6 +18,14 @@ module.exports = {
 				"SwitchCase": 1
 			}
 		],
+		"quotes": [
+			"error",
+			"double",
+			{
+				"avoidEscape": true,
+				"allowTemplateLiterals": true
+			}
+		],
 		"@typescript-eslint/no-parameter-properties": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-use-before-define": [
@@ -45,14 +53,6 @@ module.exports = {
 		"@typescript-eslint/no-object-literal-type-assertion": "off",
 		"@typescript-eslint/interface-name-prefix": "off",
 		"@typescript-eslint/no-non-null-assertion": "off", // This is necessary for Map.has()/get()!
-		"quotes": [
-			"error",
-			"double",
-			{
-				"avoidEscape": true,
-				"allowTemplateLiterals": true
-			}
-		],
 		"no-var": "error",
 		"prefer-const": "error",
 	},

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.vscode/extensions.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"dbaeumer.vscode-eslint"
+	]
+}

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.vscode/settings.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"eslint.enable": true
+}

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/keywords/package.json
+++ b/test/baselines/keywords/package.json
@@ -38,7 +38,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",

--- a/test/baselines/vis_Widget/package.json
+++ b/test/baselines/vis_Widget/package.json
@@ -23,7 +23,7 @@
     "@iobroker/testing": "^1.2.0",
     "@types/gulp": "^4.0.6",
     "axios": "^0.18.0",
-    "gulp": "^4.0.1"
+    "gulp": "^4.0.2"
   },
   "main": "widgets/test-widget.html",
   "scripts": {

--- a/test/create-adapter.test.ts
+++ b/test/create-adapter.test.ts
@@ -120,6 +120,18 @@ describe("adapter creation =>", () => {
 				"must not contain the words",
 			);
 		});
+
+		it("selecting Prettier without ESLint", () => {
+			const answers: Answers = {
+				...baseAnswers,
+				tools: ["Prettier"],
+			};
+			expectFail(
+				"invalidAnswersPrettierWithoutESLint",
+				answers,
+				"ESLint must be selected",
+			);
+		});
 	});
 
 	describe("generate baselines =>", function() {
@@ -305,7 +317,22 @@ describe("adapter creation =>", () => {
 					return (
 						(file.name.endsWith(".ts") &&
 							!file.name.endsWith(".d.ts")) ||
-						file.name === "eslint.json"
+						file.name.startsWith(".eslint")
+					);
+				});
+			});
+
+			it(`TS with Prettier`, async () => {
+				const answers: Answers = {
+					...baseAnswers,
+					tools: ["ESLint", "Prettier"],
+				};
+				await expectSuccess("TS_Prettier", answers, file => {
+					return (
+						file.name.startsWith(".vscode/") ||
+						file.name.startsWith(".eslint") ||
+						file.name.startsWith(".prettier") ||
+						file.name === "package.json"
 					);
 				});
 			});


### PR DESCRIPTION
**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [x] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] ~~If you added a required option, also add it to the template creation (`travis/create_templates.ts`)~~
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
This PR adds [Prettier](https://prettier.io/) as a tool option in TypeScript. JS support will follow. Enabling this option also enables other auto-formatting tools in VSCode.
