### PR TITLE
Use ESLint to fix quotes in TypeScript 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 	(at the beginning of a new line )
 -->
 
+## __WORK IN PROGRESS__
+* (AlCalzone) Use ESLint to fix quotes in TypeScript (#165)
+
 ## v1.13.0 (2019-05-06)
 * (AlCalzone) Remove extraneous quotes from "initial commit" (#159)
 * (AlCalzone) Switch TypeScript templates to ESLint (#158)

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -16,6 +16,9 @@ import { testCondition } from "./createAdapter";
 import { licenses } from "./licenses";
 import { getOwnVersion } from "./tools";
 
+// This is being used to simulate wrong options for conditions on the type level
+const __misused: unique symbol = Symbol.for("__misused");
+
 // Sadly, Enquirer does not export the PromptOptions type
 type PromptOptions = Exclude<Parameters<typeof prompt>[0], Function | any[]>;
 type QuestionAction<T> = (
@@ -26,7 +29,8 @@ export type AnswerValue = string | boolean | number;
 export type Condition = { name: string } & (
 	| { value: AnswerValue | AnswerValue[] }
 	| { contains: AnswerValue }
-	| { doesNotContain: AnswerValue });
+	| { doesNotContain: AnswerValue }
+	| { [__misused]: undefined });
 
 interface QuestionMeta {
 	condition?: Condition | Condition[];

--- a/src/lib/tools.test.ts
+++ b/src/lib/tools.test.ts
@@ -100,9 +100,8 @@ fn1(\`'\`);
 fn2('\\"');
 `;
 
-		// TS does not avoid escaping as opposed to ESLint
 		const expected = `const foo = '';
-const bar = '\\'';
+const bar = "'";
 fn1(\`'\`);
 fn2('\\"');
 `;

--- a/templates/admin/icon.png.ts
+++ b/templates/admin/icon.png.ts
@@ -6,7 +6,7 @@ const templateFunction: TemplateFunction = answers => {
 			// Try to decode Base64
 			const base64Match = answers.icon.match(/^data:image\/(\w+);base64,(.+)$/);
 			if (base64Match) {
-				return new Buffer(base64Match[2], "base64");
+				return Buffer.from(base64Match[2], "base64");
 			}
 			throw new Error("The icon has an unsupported string encoding!");
 		} else {

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "sinon": "^7.3.2",

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -35,7 +35,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "sinon": "^7.3.2",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.12.1
+ * Created with @iobroker/create-adapter v1.13.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/keywords/package.json
+++ b/test/baselines/keywords/package.json
@@ -38,7 +38,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "mocha": "^6.1.4",
     "proxyquire": "^2.1.0",
     "rimraf": "^2.6.3",

--- a/test/baselines/vis_Widget/package.json
+++ b/test/baselines/vis_Widget/package.json
@@ -23,7 +23,7 @@
     "@iobroker/testing": "^1.2.0",
     "@types/gulp": "^4.0.6",
     "axios": "^0.18.0",
-    "gulp": "^4.0.1"
+    "gulp": "^4.0.2"
   },
   "main": "widgets/test-widget.html",
   "scripts": {


### PR DESCRIPTION
**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] ~~If you added a required option, also add it to the template creation (`travis/create_templates.ts`)~~
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
We already used ESLint to format JS code during generation, now we use it for TypeScript aswell
