### PR TITLE
Change "ioboker" to "iobroker" in the example log messages

### DIFF
--- a/templates/main.es6.js.ts
+++ b/templates/main.es6.js.ts
@@ -94,7 +94,7 @@ ${adapterSettings.map(s => `\t\tthis.log.info("config ${s.key}: " + this.config.
 
 		// examples for the checkPassword/checkGroup functions
 		let result = await this.checkPasswordAsync("admin", "iobroker");
-		this.log.info("check user admin pw ioboker: " + result);
+		this.log.info("check user admin pw iobroker: " + result);
 
 		result = await this.checkGroupAsync("admin", "admin");
 		this.log.info("check group user admin group admin: " + result);

--- a/templates/main.js.ts
+++ b/templates/main.js.ts
@@ -138,7 +138,7 @@ ${adapterSettings.map(s => `\tadapter.log.info("config ${s.key}: " + adapter.con
 
 	// examples for the checkPassword/checkGroup functions
 	adapter.checkPassword("admin", "iobroker", (res) => {
-		adapter.log.info("check user admin pw ioboker: " + res);
+		adapter.log.info("check user admin pw iobroker: " + res);
 	});
 
 	adapter.checkGroup("admin", "admin", (res) => {

--- a/templates/src/main.es6.ts
+++ b/templates/src/main.es6.ts
@@ -104,7 +104,7 @@ ${adapterSettings.map(s => `\t\tthis.log.info("config ${s.key}: " + this.config.
 
 		// examples for the checkPassword/checkGroup functions
 		let result = await this.checkPasswordAsync("admin", "iobroker");
-		this.log.info("check user admin pw ioboker: " + result);
+		this.log.info("check user admin pw iobroker: " + result);
 
 		result = await this.checkGroupAsync("admin", "admin");
 		this.log.info("check group user admin group admin: " + result);

--- a/templates/src/main.ts.ts
+++ b/templates/src/main.ts.ts
@@ -148,7 +148,7 @@ ${adapterSettings.map(s => `\tadapter.log.info("config ${s.key}: " + adapter.con
 
 	// examples for the checkPassword/checkGroup functions
 	adapter.checkPassword("admin", "iobroker", (res) => {
-		adapter.log.info("check user admin pw ioboker: " + res);
+		adapter.log.info("check user admin pw iobroker: " + res);
 	});
 
 	adapter.checkGroup("admin", "admin", (res) => {

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -132,7 +132,7 @@ function main(): void {
 
 	// examples for the checkPassword/checkGroup functions
 	adapter.checkPassword('admin', 'iobroker', (res) => {
-		adapter.log.info('check user admin pw ioboker: ' + res);
+		adapter.log.info('check user admin pw iobroker: ' + res);
 	});
 
 	adapter.checkGroup('admin', 'admin', (res) => {

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -75,7 +75,7 @@ class TestAdapter extends utils.Adapter {
 
         // examples for the checkPassword/checkGroup functions
         let result = await this.checkPasswordAsync('admin', 'iobroker');
-        this.log.info('check user admin pw ioboker: ' + result);
+        this.log.info('check user admin pw iobroker: ' + result);
 
         result = await this.checkGroupAsync('admin', 'admin');
         this.log.info('check group user admin group admin: ' + result);

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -121,7 +121,7 @@ function main() {
 
     // examples for the checkPassword/checkGroup functions
     adapter.checkPassword('admin', 'iobroker', (res) => {
-        adapter.log.info('check user admin pw ioboker: ' + res);
+        adapter.log.info('check user admin pw iobroker: ' + res);
     });
 
     adapter.checkGroup('admin', 'admin', (res) => {

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -85,7 +85,7 @@ class TestAdapter extends utils.Adapter {
 
 		// examples for the checkPassword/checkGroup functions
 		let result = await this.checkPasswordAsync("admin", "iobroker");
-		this.log.info("check user admin pw ioboker: " + result);
+		this.log.info("check user admin pw iobroker: " + result);
 
 		result = await this.checkGroupAsync("admin", "admin");
 		this.log.info("check group user admin group admin: " + result);

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -132,7 +132,7 @@ function main(): void {
 
 	// examples for the checkPassword/checkGroup functions
 	adapter.checkPassword("admin", "iobroker", (res) => {
-		adapter.log.info("check user admin pw ioboker: " + res);
+		adapter.log.info("check user admin pw iobroker: " + res);
 	});
 
 	adapter.checkGroup("admin", "admin", (res) => {

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -135,7 +135,7 @@ function main(): void {
 
 	// examples for the checkPassword/checkGroup functions
 	adapter.checkPassword("admin", "iobroker", (res) => {
-		adapter.log.info("check user admin pw ioboker: " + res);
+		adapter.log.info("check user admin pw iobroker: " + res);
 	});
 
 	adapter.checkGroup("admin", "admin", (res) => {

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -132,7 +132,7 @@ function main(): void {
 
 	// examples for the checkPassword/checkGroup functions
 	adapter.checkPassword("admin", "iobroker", (res) => {
-		adapter.log.info("check user admin pw ioboker: " + res);
+		adapter.log.info("check user admin pw iobroker: " + res);
 	});
 
 	adapter.checkGroup("admin", "admin", (res) => {


### PR DESCRIPTION
**PR Checklist:**  
- [X] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [X] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [X] Ensure the project builds with `npm run build`
- [ ] If you added a required option, also add it to the template creation (`travis/create_templates.ts`)
- [ ] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  

During my first adapter implementation, I stumbled over this log message:
`check user admin pw ioboker: true`

I think that there is a `r` missing in the `ioboker`.

I did not add anything to the `CHANGELOG.md` as I don't think that this change warrants a mention there.