### PR TITLE
Bump Node.js typings in adapters to v12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 	(at the beginning of a new line )
 -->
 
+## __WORK IN PROGRESS__
+* (AlCalzone) Bump Node.js typings in generated adapters (`@types/node`) to 12.x
+
 ## 1.21.1 (2020-02-03)
 * (AlCalzone) Add `tsconfig.json` to `.npmignore` if type-checking is enabled (fixes #395)
 

--- a/templates/package.json.ts
+++ b/templates/package.json.ts
@@ -44,7 +44,7 @@ const templateFunction: TemplateFunction = async answers => {
 			"@types/proxyquire",
 			"proxyquire",
 			// and NodeJS typings
-			"@types/node@10",
+			"@types/node@12",
 		] : [])
 		.concat(useTypeScript ? [
 			// enhance testing through TS tools
@@ -86,8 +86,8 @@ const templateFunction: TemplateFunction = async answers => {
 	},
 	${answers.contributors && answers.contributors.length ? (`
 		"contributors": ${JSON.stringify(
-			answers.contributors.map(name => ({ name }))
-		)},
+		answers.contributors.map(name => ({ name }))
+	)},
 	`) : ""}
 	"homepage": "https://github.com/${answers.authorGithub}/ioBroker.${answers.adapterName}",
 	"license": "${answers.license!.id}",

--- a/test/baselines/TS_Prettier/package.json
+++ b/test/baselines/TS_Prettier/package.json
@@ -27,7 +27,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -27,7 +27,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/package.json
@@ -27,7 +27,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -27,7 +27,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -27,7 +27,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/contributors/package.json
+++ b/test/baselines/contributors/package.json
@@ -35,7 +35,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.21.0
+ * Created with @iobroker/create-adapter v1.21.1
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/git_SSH/package.json
+++ b/test/baselines/git_SSH/package.json
@@ -27,7 +27,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/test/baselines/keywords/package.json
+++ b/test/baselines/keywords/package.json
@@ -28,7 +28,7 @@
     "@types/chai-as-promised": "^7.1.2",
     "@types/gulp": "^4.0.6",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^10.17.14",
+    "@types/node": "^12.12.26",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",


### PR DESCRIPTION
<!--
	Thanks for providing a PR! 
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] If you added a required option, also add it to the template creation (`travis/create_templates.ts`)
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
Now that Node 12 is LTS, we should use the corresponding typings
