### PR TITLE
Re-enable Travis CI as the default CI in adapters and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## __WORK IN PROGRESS__
 * (AlCalzone) Bump Node.js typings in generated adapters (`@types/node`) to 12.x
 * (AlCalzone) Add link to best practices in the generated adapter README (fixes #417)
+* (AlCalzone) Re-enable Travis CI as the default CI in adapters
 
 ## 1.21.1 (2020-02-03)
 * (AlCalzone) Add `tsconfig.json` to `.npmignore` if type-checking is enabled (fixes #395)

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,7 +1,19 @@
 import { isArray } from "alcalzone-shared/typeguards";
 import { dim, gray, green, underline } from "ansi-colors";
 import { SpecificPromptOptions } from "enquirer";
-import { checkAdapterName, checkAuthorName, checkEmail, checkMinSelections, CheckResult, checkTitle, checkTypeScriptTools, transformAdapterName, transformContributors, transformDescription, transformKeywords } from "./actionsAndTransformers";
+import {
+	checkAdapterName,
+	checkAuthorName,
+	checkEmail,
+	checkMinSelections,
+	CheckResult,
+	checkTitle,
+	checkTypeScriptTools,
+	transformAdapterName,
+	transformContributors,
+	transformDescription,
+	transformKeywords,
+} from "./actionsAndTransformers";
 import { testCondition } from "./createAdapter";
 import { licenses } from "./licenses";
 import { getOwnVersion } from "./tools";
@@ -580,11 +592,11 @@ export const questionsAndText: (Question | QuestionGroup | string)[] = [
 				name: "ci",
 				expert: true,
 				message: "Which continuous integration service should be used?",
-				initial: [0],
+				initial: ((answers: Answers) =>
+					answers.features.includes("adapter") ? [1] : [0]) as any,
 				choices: [
 					{
 						message: "GitHub Actions",
-						hint: "(recommended)",
 						value: "gh-actions",
 					},
 					{

--- a/travis/create_templates.ts
+++ b/travis/create_templates.ts
@@ -27,7 +27,7 @@ const baseAnswers = {
 	authorGithub: "Author",
 	authorEmail: "author@mail.com",
 	gitRemoteProtocol: "HTTPS",
-	ci: ["gh-actions"],
+	ci: ["travis"],
 	license: "MIT License" as any,
 } as Answers;
 


### PR DESCRIPTION
<!--
	Thanks for providing a PR! 
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
- [x] Run the test suite with `npm test`
- [ ] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] ~~If you added a required option, also add it to the template creation (`travis/create_templates.ts`)~~
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
Since there's no overview functionality in Github Actions yet, we re-enable Travis as the default CI option.
