### PR TITLE
Drop Node 8 from testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## __WORK IN PROGRESS__
 * (Mic-M) Don't auto-translate empty texts (fixes #462)
+* (AlCalzone) Drop Node.js 8 from testing
 
 ## 1.23.0 (2020-03-17)
 * (AlCalzone) Update `.travis.yml` in the template to `gcc 6`

--- a/templates/_github/workflows/test-and-release.yml.ts
+++ b/templates/_github/workflows/test-and-release.yml.ts
@@ -10,7 +10,7 @@ const templateFunction: TemplateFunction = answers => {
 	const useESLint = answers.tools && answers.tools.indexOf("ESLint") > -1;
 
 	const latestNodeVersion = "12.x";
-	const adapterTestVersions = ["8.x", "10.x", "12.x"];
+	const adapterTestVersions = ["10.x", "12.x"];
 	const adapterTestOS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
 	const template = `

--- a/templates/_travis.yml.ts
+++ b/templates/_travis.yml.ts
@@ -15,7 +15,6 @@ os:
 
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.github/workflows/test-and-release.yml
@@ -48,12 +48,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [8.x, 10.x, 12.x]
+                node-version: [10.x, 12.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                exclude:
-                    # Don't test Node.js 8 on Windows. npm is weird here
-                    - os: windows-latest
-                      node-version: 8.x
+
         steps:
             - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/.github/workflows/test-and-release.yml
@@ -48,12 +48,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [8.x, 10.x, 12.x]
+                node-version: [10.x, 12.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                exclude:
-                    # Don't test Node.js 8 on Windows. npm is weird here
-                    - os: windows-latest
-                      node-version: 8.x
+
         steps:
             - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
@@ -51,12 +51,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [8.x, 10.x, 12.x]
+                node-version: [10.x, 12.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                exclude:
-                    # Don't test Node.js 8 on Windows. npm is weird here
-                    - os: windows-latest
-                      node-version: 8.x
+
         steps:
             - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
@@ -51,12 +51,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                node-version: [8.x, 10.x, 12.x]
+                node-version: [10.x, 12.x]
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                exclude:
-                    # Don't test Node.js 8 on Windows. npm is weird here
-                    - os: windows-latest
-                      node-version: 8.x
+
         steps:
             - uses: actions/checkout@v1
             - name: Use Node.js ${{ matrix.node-version }}

--- a/test/baselines/ci_Travis/.travis.yml
+++ b/test/baselines/ci_Travis/.travis.yml
@@ -5,7 +5,6 @@ os:
 
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 

--- a/test/baselines/vis_Widget_Travis/.travis.yml
+++ b/test/baselines/vis_Widget_Travis/.travis.yml
@@ -5,7 +5,6 @@ os:
 
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 


### PR DESCRIPTION
<!--
	Thanks for providing a PR! 
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] If you added a required option, also add it to the template creation (`travis/create_templates.ts`)
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
Node.js 8 is no longer supported by JS-Controller 3.0.