### PR TITLE
Fix Adapter options typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 	(at the beginning of a new line )
 -->
 
+## __WORK IN PROGRESS__
+* (AlCalzone) Fixed compatibility with `@types/iobroker@3.0.6`
+
 ## 1.24.1 (2020-04-21)
 * (AlCalzone) Move `@typescript-eslint/parser` to dependencies to fix crash when building TypeScript adapters.
 

--- a/templates/main.es6.js.ts
+++ b/templates/main.es6.js.ts
@@ -29,7 +29,7 @@ const utils = require("@iobroker/adapter-core");
 class ${className} extends utils.Adapter {
 
 	/**
-	 * @param {Partial<ioBroker.AdapterOptions>} [options={}]
+	 * @param {Partial<utils.AdapterOptions>} [options={}]
 	 */
 	constructor(options) {
 		super({
@@ -166,7 +166,7 @@ ${adapterSettings.map(s => `\t\tthis.log.info("config ${s.key}: " + this.config.
 if (module.parent) {
 	// Export the constructor in compact mode
 	/**
-	 * @param {Partial<ioBroker.AdapterOptions>} [options={}]
+	 * @param {Partial<utils.AdapterOptions>} [options={}]
 	 */
 	module.exports = (options) => new ${className}(options);
 } else {

--- a/templates/main.js.ts
+++ b/templates/main.js.ts
@@ -32,7 +32,7 @@ let adapter;
 
 /**
  * Starts the adapter instance
- * @param {Partial<ioBroker.AdapterOptions>} [options]
+ * @param {Partial<utils.AdapterOptions>} [options]
  */
 function startAdapter(options) {
 	// Create the adapter and define its methods

--- a/templates/src/main.es6.ts
+++ b/templates/src/main.es6.ts
@@ -40,7 +40,7 @@ ${adapterSettings.map(s => `\t\t\t${s.key}: ${typeof s.defaultValue};`).join("\n
 
 class ${className} extends utils.Adapter {
 
-	public constructor(options: Partial<ioBroker.AdapterOptions> = {}) {
+	public constructor(options: Partial<utils.AdapterOptions> = {}) {
 		super({
 			...options,
 			name: "${answers.adapterName}",
@@ -168,7 +168,7 @@ ${adapterSettings.map(s => `\t\tthis.log.info("config ${s.key}: " + this.config.
 
 if (module.parent) {
 	// Export the constructor in compact mode
-	module.exports = (options: Partial<ioBroker.AdapterOptions> | undefined) => new ${className}(options);
+	module.exports = (options: Partial<utils.AdapterOptions> | undefined) => new ${className}(options);
 } else {
 	// otherwise start the instance directly
 	(() => new ${className}())();

--- a/templates/src/main.ts.ts
+++ b/templates/src/main.ts.ts
@@ -41,7 +41,7 @@ let adapter: ioBroker.Adapter;
 /**
  * Starts the adapter instance
  */
-function startAdapter(options: Partial<ioBroker.AdapterOptions> = {}): ioBroker.Adapter {
+function startAdapter(options: Partial<utils.AdapterOptions> = {}): ioBroker.Adapter {
 	// Create the adapter and define its methods
 	return adapter = utils.adapter({
 		// Default options

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -29,7 +29,7 @@ let adapter: ioBroker.Adapter;
 /**
  * Starts the adapter instance
  */
-function startAdapter(options: Partial<ioBroker.AdapterOptions> = {}): ioBroker.Adapter {
+function startAdapter(options: Partial<utils.AdapterOptions> = {}): ioBroker.Adapter {
 	// Create the adapter and define its methods
 	return adapter = utils.adapter({
 		// Default options

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -14,7 +14,7 @@ const utils = require('@iobroker/adapter-core');
 class TestAdapter extends utils.Adapter {
 
     /**
-     * @param {Partial<ioBroker.AdapterOptions>} [options={}]
+     * @param {Partial<utils.AdapterOptions>} [options={}]
      */
     constructor(options) {
         super({
@@ -147,7 +147,7 @@ class TestAdapter extends utils.Adapter {
 if (module.parent) {
     // Export the constructor in compact mode
     /**
-     * @param {Partial<ioBroker.AdapterOptions>} [options={}]
+     * @param {Partial<utils.AdapterOptions>} [options={}]
      */
     module.exports = (options) => new TestAdapter(options);
 } else {

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_LGPLv3/main.js
@@ -19,7 +19,7 @@ let adapter;
 
 /**
  * Starts the adapter instance
- * @param {Partial<ioBroker.AdapterOptions>} [options]
+ * @param {Partial<utils.AdapterOptions>} [options]
  */
 function startAdapter(options) {
     // Create the adapter and define its methods

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -26,7 +26,7 @@ declare global {
 
 class TestAdapter extends utils.Adapter {
 
-	public constructor(options: Partial<ioBroker.AdapterOptions> = {}) {
+	public constructor(options: Partial<utils.AdapterOptions> = {}) {
 		super({
 			...options,
 			name: "test-adapter",
@@ -149,7 +149,7 @@ class TestAdapter extends utils.Adapter {
 
 if (module.parent) {
 	// Export the constructor in compact mode
-	module.exports = (options: Partial<ioBroker.AdapterOptions> | undefined) => new TestAdapter(options);
+	module.exports = (options: Partial<utils.AdapterOptions> | undefined) => new TestAdapter(options);
 } else {
 	// otherwise start the instance directly
 	(() => new TestAdapter())();

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -29,7 +29,7 @@ let adapter: ioBroker.Adapter;
 /**
  * Starts the adapter instance
  */
-function startAdapter(options: Partial<ioBroker.AdapterOptions> = {}): ioBroker.Adapter {
+function startAdapter(options: Partial<utils.AdapterOptions> = {}): ioBroker.Adapter {
 	// Create the adapter and define its methods
 	return adapter = utils.adapter({
 		// Default options

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -29,7 +29,7 @@ let adapter: ioBroker.Adapter;
 /**
  * Starts the adapter instance
  */
-function startAdapter(options: Partial<ioBroker.AdapterOptions> = {}): ioBroker.Adapter {
+function startAdapter(options: Partial<utils.AdapterOptions> = {}): ioBroker.Adapter {
 	// Create the adapter and define its methods
 	return adapter = utils.adapter({
 		// Default options

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -29,7 +29,7 @@ let adapter: ioBroker.Adapter;
 /**
  * Starts the adapter instance
  */
-function startAdapter(options: Partial<ioBroker.AdapterOptions> = {}): ioBroker.Adapter {
+function startAdapter(options: Partial<utils.AdapterOptions> = {}): ioBroker.Adapter {
 	// Create the adapter and define its methods
 	return adapter = utils.adapter({
 		// Default options


### PR DESCRIPTION
<!--
	Thanks for providing a PR! 
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**  
- [x] Provide a meaningful description to this PR or mention which issues this fixes.
- [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
- [x] Run the test suite with `npm test`
- [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
- [x] Ensure the project builds with `npm run build`
- [ ] If you added a required option, also add it to the template creation (`travis/create_templates.ts`)
- [x] Add your changes to `CHANGELOG.md` (referencing this PR or the issue you fixed)

**Description:**  
The adapter options typings of `adapter-core` are not 100% compatible with `@types/iobroker`. This PR fixes that.
