### PR TITLE
Replace deprecated ::set-env in github action 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * (AlCalzone) Make ts-node respect the "include" key in tsconfig.json (#603)
 * (UncleSamSwiss) Fixed issue with running parcel in Devcontainer (with WSL2 remote path)
 * (UncleSamSwiss) Cleaned up `.npmignore` file (#608)
+* (AlCalzone) The GitHub Actions release workflow now longer uses the [deprecated `set-env`](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) command (#611) · [Migration guide](docs/updates/20201029_gh_actions_setenv.md)
 
 ## 1.29.1 (2020-09-28)
 * (UncleSamSwiss) Remove rsync from parcel devcontainer (#589) · [Migration guide](docs/updates/20200924_devcontainer_parcel.md)

--- a/docs/updates/20201029_gh_actions_setenv.md
+++ b/docs/updates/20201029_gh_actions_setenv.md
@@ -1,0 +1,17 @@
+# Replace the deprecated `set-env` command in GitHub Actions workflow
+
+GitHub has announced that `set-env` is [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for security reasons and will stop working in the future. We're using this command in the automatic release workflow. To update, change `.github/workflows/test-and-release.yml` as follows:
+
+```diff
+  run: |
+    VERSION="${{ github.ref }}"
+    VERSION=${VERSION##*/v}
+-   echo "::set-env name=VERSION::$VERSION"
++   echo "VERSION=$VERSION" >> $GITHUB_ENV
+    BODY=$(git show -s --format=%b)
+    BODY="${BODY//'%'/'%25'}"
+    BODY="${BODY//$'\n'/'%0A'}"
+    BODY="${BODY//$'\r'/'%0D'}"
+-   echo "::set-env name=BODY::$BODY"
++   echo "BODY=$BODY" >> $GITHUB_ENV
+```

--- a/templates/_github/workflows/test-and-release.yml.ts
+++ b/templates/_github/workflows/test-and-release.yml.ts
@@ -139,12 +139,12 @@ ${(adapterTestOS.includes("windows-latest")) ? (`
 #              run: |
 #                  VERSION="\${{ github.ref }}"
 #                  VERSION=\${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="\${BODY//'%'/'%25'}"
 #                  BODY="\${BODY//$'\\n'/'%0A'}"
 #                  BODY="\${BODY//$'\\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 ${useTypeScript ? (
 `#
 #            - name: Install Dependencies

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
@@ -110,12 +110,12 @@ jobs:
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 #
 #            - name: Publish package to npm
 #              run: |

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
@@ -110,12 +110,12 @@ jobs:
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 #
 #            - name: Publish package to npm
 #              run: |

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
@@ -113,12 +113,12 @@ jobs:
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 #
 #            - name: Install Dependencies
 #              run: npm ci

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
@@ -113,12 +113,12 @@ jobs:
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 #
 #            - name: Install Dependencies
 #              run: npm ci

--- a/test/baselines/adapter_TS_React/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_React/.github/workflows/test-and-release.yml
@@ -113,12 +113,12 @@ jobs:
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 #
 #            - name: Install Dependencies
 #              run: npm ci

--- a/test/baselines/vis_Widget/.github/workflows/test-and-release.yml
+++ b/test/baselines/vis_Widget/.github/workflows/test-and-release.yml
@@ -74,12 +74,12 @@ jobs:
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "::set-env name=VERSION::$VERSION"
+#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "::set-env name=BODY::$BODY"
+#                  echo "BODY=$BODY" >> $GITHUB_ENV
 #
 #            - name: Publish package to npm
 #              run: |


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] ~~If you added a required option, also add it to the template creation (`.github/create_templates.ts`)~~
-   [x] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
`::set-env` is [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) - this PR replaces it with the now recommended way to set env variables
