### PR TITLE
Use set-output instead of ENV files to extract release body and version 

### DIFF
--- a/docs/updates/20201029_gh_actions_setenv.md
+++ b/docs/updates/20201029_gh_actions_setenv.md
@@ -3,15 +3,21 @@
 GitHub has announced that `set-env` is [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for security reasons and will stop working in the future. We're using this command in the automatic release workflow. To update, change `.github/workflows/test-and-release.yml` as follows:
 
 ```diff
-  run: |
-    VERSION="${{ github.ref }}"
-    VERSION=${VERSION##*/v}
--   echo "::set-env name=VERSION::$VERSION"
-+   echo "VERSION=$VERSION" >> $GITHUB_ENV
-    BODY=$(git show -s --format=%b)
-    BODY="${BODY//'%'/'%25'}"
-    BODY="${BODY//$'\n'/'%0A'}"
-    BODY="${BODY//$'\r'/'%0D'}"
--   echo "::set-env name=BODY::$BODY"
-+   echo "BODY=$BODY" >> $GITHUB_ENV
+    - name: Extract the version and commit body from the tag
++     id: extract_release
+      # The body may be multiline, therefore we need to escape some characters
+      run: |
+        VERSION="${{ github.ref }}"
+        VERSION=${VERSION##*/v}
+-       echo "::set-env name=VERSION::$VERSION"
++       echo "::set-output name=VERSION::$VERSION"
+        BODY=$(git show -s --format=%b)
+        BODY="${BODY//'%'/'%25'}"
+        BODY="${BODY//$'\n'/'%0A'}"
+        BODY="${BODY//$'\r'/'%0D'}"
+        echo "BODY=$BODY" >> $GITHUB_ENV
+-       echo "::set-env name=BODY::$BODY"
++       echo "::set-output name=BODY::$BODY"
 ```
+
+Also replace **ALL** occurences of `env.VERSION` with `steps.extract_release.outputs.VERSION` and `env.BODY` with `steps.extract_release.outputs.BODY`.

--- a/templates/_github/workflows/test-and-release.yml.ts
+++ b/templates/_github/workflows/test-and-release.yml.ts
@@ -113,11 +113,10 @@ ${(adapterTestOS.includes("windows-latest")) ? (`
 #    deploy:
 #        needs: [${isAdapter ? "adapter-tests" : "check-and-lint"}]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -135,16 +134,17 @@ ${(adapterTestOS.includes("windows-latest")) ? (`
 #                  node-version: \${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="\${{ github.ref }}"
 #                  VERSION=\${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="\${BODY//'%'/'%25'}"
 #                  BODY="\${BODY//$'\\n'/'%0A'}"
 #                  BODY="\${BODY//$'\\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 ${useTypeScript ? (
 `#
 #            - name: Install Dependencies
@@ -164,11 +164,11 @@ ${useTypeScript ? (
 #                  GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: \${{ github.ref }}
-#                  release_name: Release v\${{ env.VERSION }}
+#                  release_name: Release v\${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: \${{ contains(env.VERSION, '-') }}
-#                  body: \${{ env.BODY }}
+#                  prerelease: \${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: \${{ steps.extract_release.outputs.BODY }}
 `;
 	return template.trimLeft();
 };

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
@@ -84,11 +84,10 @@ jobs:
 #    deploy:
 #        needs: [adapter-tests]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -106,16 +105,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Publish package to npm
 #              run: |
@@ -129,8 +129,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.github/workflows/test-and-release.yml
@@ -84,11 +84,10 @@ jobs:
 #    deploy:
 #        needs: [adapter-tests]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -106,16 +105,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Publish package to npm
 #              run: |
@@ -129,8 +129,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}

--- a/test/baselines/adapter_JS_React/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_JS_React/.github/workflows/test-and-release.yml
@@ -84,11 +84,10 @@ jobs:
 #    deploy:
 #        needs: [adapter-tests]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -106,16 +105,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Publish package to npm
 #              run: |
@@ -129,8 +129,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
@@ -87,11 +87,10 @@ jobs:
 #    deploy:
 #        needs: [adapter-tests]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -109,16 +108,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Install Dependencies
 #              run: npm ci
@@ -137,8 +137,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.github/workflows/test-and-release.yml
@@ -87,11 +87,10 @@ jobs:
 #    deploy:
 #        needs: [adapter-tests]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -109,16 +108,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Install Dependencies
 #              run: npm ci
@@ -137,8 +137,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}

--- a/test/baselines/adapter_TS_React/.github/workflows/test-and-release.yml
+++ b/test/baselines/adapter_TS_React/.github/workflows/test-and-release.yml
@@ -87,11 +87,10 @@ jobs:
 #    deploy:
 #        needs: [adapter-tests]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -109,16 +108,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Install Dependencies
 #              run: npm ci
@@ -137,8 +137,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}

--- a/test/baselines/vis_Widget/.github/workflows/test-and-release.yml
+++ b/test/baselines/vis_Widget/.github/workflows/test-and-release.yml
@@ -48,11 +48,10 @@ jobs:
 #    deploy:
 #        needs: [check-and-lint]
 #
-#        # Trigger this step only when a commit on master is tagged with a version number
+#        # Trigger this step only when a commit on any branch is tagged with a version number
 #        if: |
 #            contains(github.event.head_commit.message, '[skip ci]') == false &&
 #            github.event_name == 'push' &&
-#            github.event.base_ref == 'refs/heads/master' &&
 #            startsWith(github.ref, 'refs/tags/v')
 #
 #        runs-on: ubuntu-latest
@@ -70,16 +69,17 @@ jobs:
 #                  node-version: ${{ matrix.node-version }}
 #
 #            - name: Extract the version and commit body from the tag
+#              id: extract_release
 #              # The body may be multiline, therefore newlines and % need to be escaped
 #              run: |
 #                  VERSION="${{ github.ref }}"
 #                  VERSION=${VERSION##*/v}
-#                  echo "VERSION=$VERSION" >> $GITHUB_ENV
+#                  echo "::set-output name=VERSION::$VERSION"
 #                  BODY=$(git show -s --format=%b)
 #                  BODY="${BODY//'%'/'%25'}"
 #                  BODY="${BODY//$'\n'/'%0A'}"
 #                  BODY="${BODY//$'\r'/'%0D'}"
-#                  echo "BODY=$BODY" >> $GITHUB_ENV
+#                  echo "::set-output name=BODY::$BODY"
 #
 #            - name: Publish package to npm
 #              run: |
@@ -93,8 +93,8 @@ jobs:
 #                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #              with:
 #                  tag_name: ${{ github.ref }}
-#                  release_name: Release v${{ env.VERSION }}
+#                  release_name: Release v${{ steps.extract_release.outputs.VERSION }}
 #                  draft: false
 #                  # Prerelease versions create prereleases on Github
-#                  prerelease: ${{ contains(env.VERSION, '-') }}
-#                  body: ${{ env.BODY }}
+#                  prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+#                  body: ${{ steps.extract_release.outputs.BODY }}


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [x] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed) - already done in #611

**Description:**  
The original fix (#611) had the unwanted side-effect that newlines were no longer escaped in the release bodies. By switching to `::set-output` and using the step outputs we have a better fix for this.