### PR TITLE
Fix compatibility with adapter-react@1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 	## __WORK IN PROGRESS__
 	(at the beginning of a new line )
 -->
+
+* (AlCalzone) Fixed compatibility with `@iobroker/adapter-react@1.4.5` (#629) · [Migration guide](docs/updates/20201105_adapter_react_fixes.md)
+
 ## 1.30.0 (2020-11-03)
-* (UncleSamSwiss) React Admin UI now uses @iobroker/adapter-react (#347) · [Migration guide](docs/updates/20201015_adapter_react.md)
+* (UncleSamSwiss) React Admin UI now uses `@iobroker/adapter-react` (#347) · [Migration guide](docs/updates/20201015_adapter_react.md)
 * (AlCalzone) Add support for JavaScript+React in the Admin UI (#609)
 * (AlCalzone) Make ts-node respect the "include" key in tsconfig.json (#603)
 * (UncleSamSwiss) Fixed issue with running parcel in Devcontainer (with WSL2 remote path)

--- a/docs/updates/20201105_adapter_react_fixes.md
+++ b/docs/updates/20201105_adapter_react_fixes.md
@@ -5,6 +5,7 @@ By enabling `esModuleInterop` and dropping the `*` import (TypeScript only), we 
 
 Migration guide:
 
+-   Remove the line `"jsx": "react"` from `tsconfig.json` in the project root.
 -   Add `"esModuleInterop": true` and `"jsx": "react"` to `admin/tsconfig.json` (inside `compilerOptions`)
 -   TypeScript only: Replace `import * as React from "react"` with `import React from "react"`
 -   TypeScript only: Replace `import * as ReactDOM from "react-dom"` with `import ReactDOM from "react-dom"`

--- a/docs/updates/20201105_adapter_react_fixes.md
+++ b/docs/updates/20201105_adapter_react_fixes.md
@@ -1,0 +1,10 @@
+# Fix compatibility with @iobroker/adapter-react@1.4.5
+
+`@iobroker/adapter-react` has switched to default-importing `React`, which causes our `* as React` imports to break the type declarations.
+By enabling `esModuleInterop` and dropping the `*` import (TypeScript only), we can fix it.
+
+Migration guide:
+
+-   Add `"esModuleInterop": true` to `tsconfig.json` (inside `compilerOptions`)
+-   TypeScript only: Replace `import * as React from "react"` with `import React from "react"`
+-   TypeScript only: Replace `import * as ReactDOM from "react-dom"` with `import ReactDOM from "react-dom"`

--- a/docs/updates/20201105_adapter_react_fixes.md
+++ b/docs/updates/20201105_adapter_react_fixes.md
@@ -5,6 +5,6 @@ By enabling `esModuleInterop` and dropping the `*` import (TypeScript only), we 
 
 Migration guide:
 
--   Add `"esModuleInterop": true` to `tsconfig.json` (inside `compilerOptions`)
+-   Add `"esModuleInterop": true` and `"jsx": "react"` to `admin/tsconfig.json` (inside `compilerOptions`)
 -   TypeScript only: Replace `import * as React from "react"` with `import React from "react"`
 -   TypeScript only: Replace `import * as ReactDOM from "react-dom"` with `import ReactDOM from "react-dom"`

--- a/templates/admin/src/app.tsx_jsx.ts
+++ b/templates/admin/src/app.tsx_jsx.ts
@@ -7,7 +7,7 @@ const templateFunction: TemplateFunction = answers => {
 	if (!useReact) return;
 
 	const template = `
-import ${useTypeScript ? "* as " : ""}React from "react";
+import React from "react";
 import { ${useTypeScript ? "Theme, " : ""}withStyles } from "@material-ui/core/styles";
 
 import GenericApp from "@iobroker/adapter-react/GenericApp";

--- a/templates/admin/src/components/settings.tsx_jsx.ts
+++ b/templates/admin/src/components/settings.tsx_jsx.ts
@@ -24,7 +24,7 @@ const templateFunction: TemplateFunction = answers => {
 	const adapterSettings: AdapterSettings[] = answers.adapterSettings ?? getDefaultAnswer("adapterSettings")!;
 
 	const template = `
-import ${useTypeScript ? "* as " : ""}React from "react";
+import React from "react";
 import { withStyles } from "@material-ui/core/styles";
 ${useTypeScript ? `import { CreateCSSProperties } from "@material-ui/core/styles/withStyles";
 ` : ""}import TextField from "@material-ui/core/TextField";

--- a/templates/admin/src/index.tsx_jsx.ts
+++ b/templates/admin/src/index.tsx_jsx.ts
@@ -7,8 +7,8 @@ const templateFunction: TemplateFunction = answers => {
 	if (!useReact) return;
 	
 	const template = `
-import ${useTypeScript ? "* as " : ""}React from "react";
-import ${useTypeScript ? "* as " : ""}ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import theme from "@iobroker/adapter-react/Theme";
 import Utils from "@iobroker/adapter-react/Components/Utils";

--- a/templates/admin/tsconfig_JS-React.raw.json
+++ b/templates/admin/tsconfig_JS-React.raw.json
@@ -11,7 +11,12 @@
 		"lib": [
 			"es2018",
 			"DOM"
-		]
+		],
+
+		// Support React - both must be here because parcel v1 does not
+		// evaluate the "extends" option
+		"jsx": "react",
+		"esModuleInterop": true
 	},
 	"include": [
 		"./**/*.d.ts",

--- a/templates/admin/tsconfig_TS-React.raw.json
+++ b/templates/admin/tsconfig_TS-React.raw.json
@@ -11,7 +11,12 @@
 		"lib": [
 			"es2018",
 			"DOM"
-		]
+		],
+
+		// Support React - both must be here because parcel v1 does not
+		// evaluate the "extends" option
+		"jsx": "react",
+		"esModuleInterop": true
 	},
 	"include": [
 		"./**/*.ts",

--- a/templates/tsconfig.json.ts
+++ b/templates/tsconfig.json.ts
@@ -30,6 +30,7 @@ export = (answers => {
 
 		// Support React
 		"jsx": "react",
+		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/templates/tsconfig.json.ts
+++ b/templates/tsconfig.json.ts
@@ -25,12 +25,9 @@ export = (answers => {
 		"removeComments": false,`) : ""}
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"esModuleInterop": true,
 		// this is necessary for the automatic typing of the adapter config
 		"resolveJsonModule": true,
-
-		// Support React
-		"jsx": "react",
-		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
@@ -26,5 +26,5 @@
     "ci": "gh-actions",
     "dependabot": "yes",
     "license": "Apache License 2.0",
-    "creatorVersion": "1.29.1"
+    "creatorVersion": "1.30.0"
 }

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
@@ -16,6 +16,7 @@
 
         // Support React
         "jsx": "react",
+        "esModuleInterop": true,
 
         // Set this to false if you want to disable the very strict rules (not recommended)
         "strict": true,

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
@@ -11,12 +11,9 @@
 
         "module": "commonjs",
         "moduleResolution": "node",
+        "esModuleInterop": true,
         // this is necessary for the automatic typing of the adapter config
         "resolveJsonModule": true,
-
-        // Support React
-        "jsx": "react",
-        "esModuleInterop": true,
 
         // Set this to false if you want to disable the very strict rules (not recommended)
         "strict": true,

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
@@ -26,5 +26,5 @@
     "ci": "gh-actions",
     "dependabot": "yes",
     "license": "Apache License 2.0",
-    "creatorVersion": "1.29.1"
+    "creatorVersion": "1.30.0"
 }

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
@@ -16,6 +16,7 @@
 
         // Support React
         "jsx": "react",
+        "esModuleInterop": true,
 
         // Set this to false if you want to disable the very strict rules (not recommended)
         "strict": true,

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/tsconfig.json
@@ -11,12 +11,9 @@
 
         "module": "commonjs",
         "moduleResolution": "node",
+        "esModuleInterop": true,
         // this is necessary for the automatic typing of the adapter config
         "resolveJsonModule": true,
-
-        // Support React
-        "jsx": "react",
-        "esModuleInterop": true,
 
         // Set this to false if you want to disable the very strict rules (not recommended)
         "strict": true,

--- a/test/baselines/adapter_JS_React/.create-adapter.json
+++ b/test/baselines/adapter_JS_React/.create-adapter.json
@@ -25,5 +25,5 @@
 	"ci": "gh-actions",
 	"dependabot": "yes",
 	"license": "MIT License",
-	"creatorVersion": "1.29.1"
+	"creatorVersion": "1.30.0"
 }

--- a/test/baselines/adapter_JS_React/main.js
+++ b/test/baselines/adapter_JS_React/main.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_React/package.json
+++ b/test/baselines/adapter_JS_React/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
-    "@iobroker/adapter-react": "^1.4.4",
+    "@iobroker/adapter-react": "^1.4.5",
     "@iobroker/testing": "^2.3.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
@@ -25,5 +25,5 @@
 	"ci": "gh-actions",
 	"dependabot": "yes",
 	"license": "MIT License",
-	"creatorVersion": "1.29.1"
+	"creatorVersion": "1.30.0"
 }

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
@@ -16,12 +16,9 @@
 		"removeComments": false,
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"esModuleInterop": true,
 		// this is necessary for the automatic typing of the adapter config
 		"resolveJsonModule": true,
-
-		// Support React
-		"jsx": "react",
-		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
@@ -21,6 +21,7 @@
 
 		// Support React
 		"jsx": "react",
+		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
@@ -28,5 +28,5 @@
 	"ci": "gh-actions",
 	"dependabot": "yes",
 	"license": "MIT License",
-	"creatorVersion": "1.29.1"
+	"creatorVersion": "1.30.0"
 }

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
@@ -16,12 +16,9 @@
 		"removeComments": false,
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"esModuleInterop": true,
 		// this is necessary for the automatic typing of the adapter config
 		"resolveJsonModule": true,
-
-		// Support React
-		"jsx": "react",
-		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/tsconfig.json
@@ -21,6 +21,7 @@
 
 		// Support React
 		"jsx": "react",
+		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/adapter_TS_React/.create-adapter.json
+++ b/test/baselines/adapter_TS_React/.create-adapter.json
@@ -25,5 +25,5 @@
 	"ci": "gh-actions",
 	"dependabot": "yes",
 	"license": "MIT License",
-	"creatorVersion": "1.29.1"
+	"creatorVersion": "1.30.0"
 }

--- a/test/baselines/adapter_TS_React/admin/src/app.tsx
+++ b/test/baselines/adapter_TS_React/admin/src/app.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Theme, withStyles } from "@material-ui/core/styles";
 
 import GenericApp from "@iobroker/adapter-react/GenericApp";

--- a/test/baselines/adapter_TS_React/admin/src/components/settings.tsx
+++ b/test/baselines/adapter_TS_React/admin/src/components/settings.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { withStyles } from "@material-ui/core/styles";
 import { CreateCSSProperties } from "@material-ui/core/styles/withStyles";
 import TextField from "@material-ui/core/TextField";

--- a/test/baselines/adapter_TS_React/admin/src/index.tsx
+++ b/test/baselines/adapter_TS_React/admin/src/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import theme from "@iobroker/adapter-react/Theme";
 import Utils from "@iobroker/adapter-react/Components/Utils";

--- a/test/baselines/adapter_TS_React/admin/tsconfig.json
+++ b/test/baselines/adapter_TS_React/admin/tsconfig.json
@@ -11,7 +11,12 @@
 		"lib": [
 			"es2018",
 			"DOM"
-		]
+		],
+
+		// Support React - both must be here because parcel v1 does not
+		// evaluate the "extends" option
+		"jsx": "react",
+		"esModuleInterop": true
 	},
 	"include": [
 		"./**/*.ts",

--- a/test/baselines/adapter_TS_React/package.json
+++ b/test/baselines/adapter_TS_React/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^14.14.6",
     "@types/proxyquire": "^1.3.28",
     "@types/react-dom": "^16.9.9",
-    "@types/react": "^16.9.55",
+    "@types/react": "^16.9.56",
     "@types/sinon": "^9.0.8",
     "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^4.6.1",

--- a/test/baselines/adapter_TS_React/package.json
+++ b/test/baselines/adapter_TS_React/package.json
@@ -27,7 +27,7 @@
     "@babel/plugin-proposal-decorators": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-typescript": "^7.12.1",
-    "@iobroker/adapter-react": "^1.4.4",
+    "@iobroker/adapter-react": "^1.4.5",
     "@iobroker/testing": "^2.3.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/test/baselines/adapter_TS_React/src/main.ts
+++ b/test/baselines/adapter_TS_React/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_React/tsconfig.json
+++ b/test/baselines/adapter_TS_React/tsconfig.json
@@ -16,12 +16,9 @@
 		"removeComments": false,
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"esModuleInterop": true,
 		// this is necessary for the automatic typing of the adapter config
 		"resolveJsonModule": true,
-
-		// Support React
-		"jsx": "react",
-		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/adapter_TS_React/tsconfig.json
+++ b/test/baselines/adapter_TS_React/tsconfig.json
@@ -21,6 +21,7 @@
 
 		// Support React
 		"jsx": "react",
+		"esModuleInterop": true,
 
 		// Set this to false if you want to disable the very strict rules (not recommended)
 		"strict": true,

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v1.29.1
+ * Created with @iobroker/create-adapter v1.30.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/vis_Widget/.create-adapter.json
+++ b/test/baselines/vis_Widget/.create-adapter.json
@@ -14,5 +14,5 @@
 	"ci": "gh-actions",
 	"dependabot": "yes",
 	"license": "MIT License",
-	"creatorVersion": "1.29.1"
+	"creatorVersion": "1.30.0"
 }

--- a/test/baselines/vis_Widget_Travis/.create-adapter.json
+++ b/test/baselines/vis_Widget_Travis/.create-adapter.json
@@ -14,5 +14,5 @@
 	"ci": "travis",
 	"dependabot": "yes",
 	"license": "MIT License",
-	"creatorVersion": "1.29.1"
+	"creatorVersion": "1.30.0"
 }


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [x] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
adapter-react has switched to default-importing `React`, which causes our `* as React` imports to break the type declarations.
By enabling `esModuleInterop` and dropping the `*` import, we can fix it.
