### PR TITLE
Use `require.main` to test if an adapter was started in compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 * (Gaudes) Add Sentry notification about new release to workflow (#690)
 * (Gaudes) Fix function declaration for translate function `_` (#691)
 * (AlCalzone) Restore compatibility with `eslint-config-prettier` v8 (#709) · [Migration guide](docs/updates/20210301_prettier_config.md)
- 
+* (AlCalzone) Replaced the now deprecated compact mode check using `module.parent` with one that uses `require.main` (#653) · [Migration guide](docs/updates/20201201_require_main.md)
+
 ## 1.31.0 (2020-11-29)
 * (crycode-de) Added better types for the `I18n.t` function based on words in `i18n/en.json` for TypeScript React UI (#630) · [Migration guide](docs/updates/20201107_typed_i18n_t.md)
 * (AlCalzone) An adapter with devcontainer but without React no longer contains files for parcel (#635) · **Migration guide:** Delete `.devcontainer/parcel` directory.

--- a/docs/updates/20201201_require_main.md
+++ b/docs/updates/20201201_require_main.md
@@ -1,0 +1,10 @@
+# Use `require.main` to test if an adapter was started in compact mode
+
+The `module.parent` is now deprecated in Node.js. As an alternative, `require.main` should be used. To update your code, just change the following line:
+
+```diff
+- if (module.parent) {
++ if (require.main !== module) {
+```
+
+If `// @ts-ignore` was used to suppress an error, you can delete it.

--- a/templates/main.es6.js.ts
+++ b/templates/main.es6.js.ts
@@ -175,8 +175,7 @@ ${adapterSettings.map(s => `\t\tthis.log.info("config ${s.key}: " + this.config.
 
 }
 
-// @ts-ignore parent is a valid property on module
-if (module.parent) {
+if (require.main !== module) {
 	// Export the constructor in compact mode
 	/**
 	 * @param {Partial<utils.AdapterOptions>} [options={}]

--- a/templates/main.js.ts
+++ b/templates/main.js.ts
@@ -160,8 +160,7 @@ ${adapterSettings.map(s => `\tadapter.log.info("config ${s.key}: " + adapter.con
 	});
 }
 
-// @ts-ignore parent is a valid property on module
-if (module.parent) {
+if (require.main !== module) {
 	// Export startAdapter in compact mode
 	module.exports = startAdapter;
 } else {

--- a/templates/src/main.es6.ts
+++ b/templates/src/main.es6.ts
@@ -165,7 +165,7 @@ ${adapterSettings.map(s => `\t\tthis.log.info("config ${s.key}: " + this.config.
 
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export the constructor in compact mode
 	module.exports = (options: Partial<utils.AdapterOptions> | undefined) => new ${className}(options);
 } else {

--- a/templates/src/main.ts.ts
+++ b/templates/src/main.ts.ts
@@ -156,7 +156,7 @@ ${adapterSettings.map(s => `\tadapter.log.info("config ${s.key}: " + adapter.con
 	});
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export startAdapter in compact mode
 	module.exports = startAdapter;
 } else {

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -138,7 +138,7 @@ async function main(): Promise<void> {
 	});
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export startAdapter in compact mode
 	module.exports = startAdapter;
 } else {

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
@@ -155,8 +155,7 @@ class TestAdapter extends utils.Adapter {
 
 }
 
-// @ts-ignore parent is a valid property on module
-if (module.parent) {
+if (require.main !== module) {
     // Export the constructor in compact mode
     /**
      * @param {Partial<utils.AdapterOptions>} [options={}]

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
@@ -142,8 +142,7 @@ async function main() {
     });
 }
 
-// @ts-ignore parent is a valid property on module
-if (module.parent) {
+if (require.main !== module) {
     // Export startAdapter in compact mode
     module.exports = startAdapter;
 } else {

--- a/test/baselines/adapter_JS_React/main.js
+++ b/test/baselines/adapter_JS_React/main.js
@@ -155,8 +155,7 @@ class TestAdapter extends utils.Adapter {
 
 }
 
-// @ts-ignore parent is a valid property on module
-if (module.parent) {
+if (require.main !== module) {
 	// Export the constructor in compact mode
 	/**
 	 * @param {Partial<utils.AdapterOptions>} [options={}]

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -144,7 +144,7 @@ class TestAdapter extends utils.Adapter {
 
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export the constructor in compact mode
 	module.exports = (options: Partial<utils.AdapterOptions> | undefined) => new TestAdapter(options);
 } else {

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -138,7 +138,7 @@ async function main(): Promise<void> {
 	});
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export startAdapter in compact mode
 	module.exports = startAdapter;
 } else {

--- a/test/baselines/adapter_TS_React/src/main.ts
+++ b/test/baselines/adapter_TS_React/src/main.ts
@@ -144,7 +144,7 @@ class TestAdapter extends utils.Adapter {
 
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export the constructor in compact mode
 	module.exports = (options: Partial<utils.AdapterOptions> | undefined) => new TestAdapter(options);
 } else {

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -141,7 +141,7 @@ async function main(): Promise<void> {
 	});
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export startAdapter in compact mode
 	module.exports = startAdapter;
 } else {

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -138,7 +138,7 @@ async function main(): Promise<void> {
 	});
 }
 
-if (module.parent) {
+if (require.main !== module) {
 	// Export startAdapter in compact mode
 	module.exports = startAdapter;
 } else {


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [x] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
Replaced the now deprecated compact mode check using `module.parent` with one that uses `require.main`
