### PR TITLE
Migrate existing adapter projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * (UncleSamSwiss) Add support for tab in Admin to use React (#674)
 * (AlCalzone) Restore compatibility with `eslint-config-prettier` v8 (#709) · [Migration guide](docs/updates/20210301_prettier_config.md)
 * (AlCalzone) Replaced the now deprecated compact mode check using `module.parent` with one that uses `require.main` (#653) · [Migration guide](docs/updates/20201201_require_main.md)
-* (UncleSamSwiss) Add support for importing an exisitng adapter project and pre-fill the answers (#712)
+* (UncleSamSwiss) Add support for migrating an existing adapter project and pre-fill the answers (#712)
 
 ## 1.31.0 (2020-11-29)
 * (crycode-de) Added better types for the `I18n.t` function based on words in `i18n/en.json` for TypeScript React UI (#630) · [Migration guide](docs/updates/20201107_typed_i18n_t.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * (UncleSamSwiss) Add support for tab in Admin to use React (#674)
 * (AlCalzone) Restore compatibility with `eslint-config-prettier` v8 (#709) · [Migration guide](docs/updates/20210301_prettier_config.md)
 * (AlCalzone) Replaced the now deprecated compact mode check using `module.parent` with one that uses `require.main` (#653) · [Migration guide](docs/updates/20201201_require_main.md)
-* (UncleSamSwiss) Add support for importing an exisitng adapter project and pre-fill the answers
+* (UncleSamSwiss) Add support for importing an exisitng adapter project and pre-fill the answers (#712)
 
 ## 1.31.0 (2020-11-29)
 * (crycode-de) Added better types for the `I18n.t` function based on words in `i18n/en.json` for TypeScript React UI (#630) · [Migration guide](docs/updates/20201107_typed_i18n_t.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * (UncleSamSwiss) Add support for tab in Admin to use React (#674)
 * (AlCalzone) Restore compatibility with `eslint-config-prettier` v8 (#709) · [Migration guide](docs/updates/20210301_prettier_config.md)
 * (AlCalzone) Replaced the now deprecated compact mode check using `module.parent` with one that uses `require.main` (#653) · [Migration guide](docs/updates/20201201_require_main.md)
+* (UncleSamSwiss) Add support for importing an exisitng adapter project and pre-fill the answers
 
 ## 1.31.0 (2020-11-29)
 * (crycode-de) Added better types for the `I18n.t` function based on words in `i18n/en.json` for TypeScript React UI (#630) · [Migration guide](docs/updates/20201107_typed_i18n_t.md)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following CLI options are available:
 -   `--target=/path/to/dir` - Specify which directory the adapter files should be created in (instead of the current dir). Shortcut: `-t`
 -   `--skipAdapterExistenceCheck` - Don't check if an adapter with the same name already exists on `npm`. Shortcut: `-x`
 -   `--replay=/path/to/file` - Re-run the adapter creator with the answers of a previous run (the given file needs to be the `.create-adapter.json` in the root of the previously generated directory). Shortcut: `-r`
+-   `--import=/path/to/dir` - Run the adapter creator with the answers pre-filled from an existing adapter directory (the given path needs to point to the adapter base directory where `io-package.json` is found). Shortcut: `-i`
 
 All CLI options can also be [provided as environment variables](https://yargs.js.org/docs/#api-reference-envprefix) by prepending `CREATE_ADAPTER_`. Example: `CREATE_ADAPTER_TARGET=/tmp/iobroker/create-adapter/`
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following CLI options are available:
 -   `--target=/path/to/dir` - Specify which directory the adapter files should be created in (instead of the current dir). Shortcut: `-t`
 -   `--skipAdapterExistenceCheck` - Don't check if an adapter with the same name already exists on `npm`. Shortcut: `-x`
 -   `--replay=/path/to/file` - Re-run the adapter creator with the answers of a previous run (the given file needs to be the `.create-adapter.json` in the root of the previously generated directory). Shortcut: `-r`
--   `--import=/path/to/dir` - Run the adapter creator with the answers pre-filled from an existing adapter directory (the given path needs to point to the adapter base directory where `io-package.json` is found). Shortcut: `-i`
+-   `--migrate=/path/to/dir` - Run the adapter creator with the answers pre-filled from an existing adapter directory (the given path needs to point to the adapter base directory where `io-package.json` is found). Shortcut: `-m`
 
 All CLI options can also be [provided as environment variables](https://yargs.js.org/docs/#api-reference-envprefix) by prepending `CREATE_ADAPTER_`. Example: `CREATE_ADAPTER_TARGET=/tmp/iobroker/create-adapter/`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,13 +89,14 @@ async function ask(): Promise<Answers> {
 		try {
 			const importDirectory = path.resolve(argv.import);
 			importContext = new ImportContext(importDirectory);
+			await importContext.load();
 		} catch (error) {
 			console.error(error);
 			throw new Error(
 				"Please ensure that --import points to a valid adapter directory",
 			);
 		}
-		if (importContext.fileExists(".create-adapter.json")) {
+		if (await importContext.fileExists(".create-adapter.json")) {
 			// it's just not worth trying to figure out things if the adapter was already created with create-adapter
 			throw new Error(
 				"Use --replay instead of --import for an adapter created with a recent version of create-adapter.",
@@ -110,7 +111,11 @@ async function ask(): Promise<Answers> {
 				q.initial = q.initial(answers);
 			}
 			if (importContext && q.import) {
-				q.initial = q.import(importContext, answers, q);
+				let imported = q.import(importContext, answers, q);
+				if (imported && typeof (imported as any).then === "function") {
+					imported = await imported;
+				}
+				q.initial = imported;
 			}
 			while (true) {
 				let answer: Record<string, any>;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,7 +113,7 @@ async function ask(): Promise<Answers> {
 			}
 			if (migrationContext && q.migrate) {
 				let migrated = q.migrate(migrationContext, answers, q);
-				if (migrated && typeof (migrated as any).then === "function") {
+				if (migrated instanceof Promise) {
 					migrated = await migrated;
 				}
 				q.initial = migrated;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,7 @@ async function ask(): Promise<Answers> {
 		try {
 			const migrationDir = path.resolve(argv.migrate);
 			migrationContext = new MigrationContext(migrationDir);
+			console.log(`Migrating from ${migrationDir}`);
 			await migrationContext.load();
 		} catch (error) {
 			console.error(error);

--- a/src/lib/importContext.ts
+++ b/src/lib/importContext.ts
@@ -1,0 +1,88 @@
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	readJsonSync,
+	statSync,
+} from "fs-extra";
+import path = require("path");
+
+export class ImportContext {
+	public readonly packageJson: any;
+	public readonly ioPackageJson: any;
+
+	constructor(private readonly baseDir: string) {
+		console.log(`Importing from ${baseDir}`);
+		this.packageJson = this.readJsonFile("package.json");
+		this.ioPackageJson = this.readJsonFile("io-package.json");
+	}
+
+	public readJsonFile<T>(fileName: string): T {
+		return readJsonSync(path.join(this.baseDir, fileName)) as T;
+	}
+
+	public directoryExists(dirName: string): boolean {
+		const fullPath = path.join(this.baseDir, dirName);
+		return existsSync(fullPath) && statSync(fullPath).isDirectory();
+	}
+
+	public fileExists(dirName: string): boolean {
+		const fullPath = path.join(this.baseDir, dirName);
+		return existsSync(fullPath) && statSync(fullPath).isFile();
+	}
+
+	public hasFilesWithExtension(dirName: string, extension: string): boolean {
+		return (
+			this.directoryExists(dirName) &&
+			!!readdirSync(path.join(this.baseDir, dirName)).find((f) =>
+				f.toLowerCase().endsWith(extension.toLowerCase()),
+			)
+		);
+	}
+
+	public hasDevDependency(packageName: string): boolean {
+		return (
+			this.packageJson.devDependencies &&
+			this.packageJson.devDependencies.hasOwnProperty(packageName)
+		);
+	}
+
+	public getMainFileContent(): string {
+		if (
+			!this.packageJson.main ||
+			!this.packageJson.main.endsWith(".js") ||
+			!this.fileExists(this.packageJson.main)
+		) {
+			// we don't have a main JavaScript file, it will be impossible to find code
+			return "";
+		}
+
+		try {
+			const tsMain = path.join(
+				this.baseDir,
+				"src",
+				this.packageJson.main.replace(/\.js$/, ".ts"),
+			);
+			if (existsSync(tsMain)) {
+				// most probably TypeScript
+				return readFileSync(tsMain, { encoding: "utf8" });
+			} else {
+				return readFileSync(
+					path.join(this.baseDir, this.packageJson.main),
+					{ encoding: "utf8" },
+				);
+			}
+		} catch {
+			// we don't want this to crash, so just return an empty string
+			return "";
+		}
+	}
+
+	public analyzeCode(either: string, or: string): boolean {
+		const content = this.getMainFileContent();
+		const eitherCount = (content.match(new RegExp(either, "g")) || [])
+			.length;
+		const orCount = (content.match(new RegExp(or, "g")) || []).length;
+		return eitherCount >= orCount;
+	}
+}

--- a/src/lib/migrationContext.test.ts
+++ b/src/lib/migrationContext.test.ts
@@ -108,19 +108,21 @@ describe("hasDevDependency()", () => {
 	});
 });
 
-// not working in GH action - but you can still use this test locally
-describe.skip("getMainFileContent()", () => {
-	it("should return the contents of the TS file if a main JS file is found with a corresponding TS file", async () => {
-		const baseDir = path.resolve(__dirname, "../..");
-		const context = new MigrationContext(baseDir);
-		context.packageJson = {
-			main: "build/src/cli.js",
-		};
-		expect(await context.getMainFileContent()).not.to.be.empty;
-		expect(await context.getMainFileContent()).to.contain(
-			"import * as yargs",
-		);
-	});
+describe("getMainFileContent()", () => {
+	if (!process.env.CI) {
+		// not working in GH action as we don't compile the JS code there
+		it("should return the contents of the TS file if a main JS file is found with a corresponding TS file", async () => {
+			const baseDir = path.resolve(__dirname, "../..");
+			const context = new MigrationContext(baseDir);
+			context.packageJson = {
+				main: "build/src/cli.js",
+			};
+			expect(await context.getMainFileContent()).not.to.be.empty;
+			expect(await context.getMainFileContent()).to.contain(
+				"import * as yargs",
+			);
+		});
+	}
 
 	it("should return the contents of the main file if a main file is found with no corresponding TS file", async () => {
 		const baseDir = path.resolve(__dirname, "../..");
@@ -145,23 +147,26 @@ describe.skip("getMainFileContent()", () => {
 });
 
 // not working in GH action - but you can still use this test locally
-describe.skip("analyzeCode()", () => {
-	it("should return true the first string occurs more than the second", async () => {
-		const baseDir = path.resolve(__dirname, "../..");
-		const context = new MigrationContext(baseDir);
-		context.packageJson = {
-			main: "build/src/cli.js",
-		};
-		expect(await context.analyzeCode("\t", "  ")).to.be.true;
-		expect(await context.analyzeCode('"', "'")).to.be.true;
-	});
-	it("should return false the first string occurs less often than the second", async () => {
-		const baseDir = path.resolve(__dirname, "../..");
-		const context = new MigrationContext(baseDir);
-		context.packageJson = {
-			main: "build/src/cli.js",
-		};
-		expect(await context.analyzeCode("  ", "\t")).to.be.false;
-		expect(await context.analyzeCode("'", '"')).to.be.false;
-	});
+describe("analyzeCode()", () => {
+	if (!process.env.CI) {
+		// not working in GH action as we don't compile the JS code there
+		it("should return true the first string occurs more than the second", async () => {
+			const baseDir = path.resolve(__dirname, "../..");
+			const context = new MigrationContext(baseDir);
+			context.packageJson = {
+				main: "build/src/cli.js",
+			};
+			expect(await context.analyzeCode("\t", "  ")).to.be.true;
+			expect(await context.analyzeCode('"', "'")).to.be.true;
+		});
+		it("should return false the first string occurs less often than the second", async () => {
+			const baseDir = path.resolve(__dirname, "../..");
+			const context = new MigrationContext(baseDir);
+			context.packageJson = {
+				main: "build/src/cli.js",
+			};
+			expect(await context.analyzeCode("  ", "\t")).to.be.false;
+			expect(await context.analyzeCode("'", '"')).to.be.false;
+		});
+	}
 });

--- a/src/lib/migrationContext.test.ts
+++ b/src/lib/migrationContext.test.ts
@@ -108,7 +108,8 @@ describe("hasDevDependency()", () => {
 	});
 });
 
-describe("getMainFileContent()", () => {
+// not working in GH action - but you can still use this test locally
+xdescribe("getMainFileContent()", () => {
 	it("should return the contents of the TS file if a main JS file is found with a corresponding TS file", async () => {
 		const baseDir = path.resolve(__dirname, "../..");
 		const context = new MigrationContext(baseDir);
@@ -143,7 +144,8 @@ describe("getMainFileContent()", () => {
 	});
 });
 
-describe("analyzeCode()", () => {
+// not working in GH action - but you can still use this test locally
+xdescribe("analyzeCode()", () => {
 	it("should return true the first string occurs more than the second", async () => {
 		const baseDir = path.resolve(__dirname, "../..");
 		const context = new MigrationContext(baseDir);

--- a/src/lib/migrationContext.test.ts
+++ b/src/lib/migrationContext.test.ts
@@ -109,7 +109,7 @@ describe("hasDevDependency()", () => {
 });
 
 // not working in GH action - but you can still use this test locally
-xdescribe("getMainFileContent()", () => {
+describe.skip("getMainFileContent()", () => {
 	it("should return the contents of the TS file if a main JS file is found with a corresponding TS file", async () => {
 		const baseDir = path.resolve(__dirname, "../..");
 		const context = new MigrationContext(baseDir);
@@ -145,7 +145,7 @@ xdescribe("getMainFileContent()", () => {
 });
 
 // not working in GH action - but you can still use this test locally
-xdescribe("analyzeCode()", () => {
+describe.skip("analyzeCode()", () => {
 	it("should return true the first string occurs more than the second", async () => {
 		const baseDir = path.resolve(__dirname, "../..");
 		const context = new MigrationContext(baseDir);

--- a/src/lib/migrationContext.test.ts
+++ b/src/lib/migrationContext.test.ts
@@ -49,12 +49,26 @@ describe("hasFilesWithExtension()", () => {
 		expect(await context.hasFilesWithExtension("../..", ".json")).to.be
 			.true;
 		expect(await context.hasFilesWithExtension("..", ".ts")).to.be.true;
+		expect(
+			await context.hasFilesWithExtension(
+				"..",
+				".ts",
+				(f) => !f.endsWith("cli.ts"),
+			),
+		).to.be.true;
 	});
 
 	it("should return false if no files exist", async () => {
 		const context = new MigrationContext(__dirname);
 		expect(await context.hasFilesWithExtension("..", ".xls")).to.be.false;
 		expect(await context.hasFilesWithExtension("..", ".dts")).to.be.false;
+		expect(
+			await context.hasFilesWithExtension(
+				"..",
+				".ts",
+				(f) => !f.includes("i"),
+			),
+		).to.be.false;
 	});
 
 	it("should return false if the directory doesn't exist", async () => {

--- a/src/lib/migrationContext.test.ts
+++ b/src/lib/migrationContext.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "chai";
+import { MigrationContext } from "./migrationContext";
+import path = require("path");
+
+describe("directoryExists()", () => {
+	it("should return true if the directory exists", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.directoryExists(".")).to.be.true;
+		expect(await context.directoryExists("../..")).to.be.true;
+		expect(await context.directoryExists("../../test")).to.be.true;
+	});
+
+	it("should return false if the directory doesn't exists", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.directoryExists("foo")).to.be.false;
+		expect(await context.directoryExists("../bar")).to.be.false;
+	});
+
+	it("should return false if it isn't a directory", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.directoryExists("../../package.json")).to.be.false;
+		expect(await context.directoryExists("../cli.ts")).to.be.false;
+	});
+});
+
+describe("fileExists()", () => {
+	it("should return true if the file exists", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.fileExists("../../package.json")).to.be.true;
+		expect(await context.fileExists("../cli.ts")).to.be.true;
+	});
+
+	it("should return false if the file doesn't exists", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.fileExists("../foo.ts")).to.be.false;
+		expect(await context.fileExists("../../bar.txt")).to.be.false;
+	});
+
+	it("should return false if it isn't a file", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.fileExists("../..")).to.be.false;
+		expect(await context.fileExists("../../test")).to.be.false;
+	});
+});
+
+describe("hasFilesWithExtension()", () => {
+	it("should return true if files exist", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.hasFilesWithExtension("../..", ".json")).to.be
+			.true;
+		expect(await context.hasFilesWithExtension("..", ".ts")).to.be.true;
+	});
+
+	it("should return false if no files exist", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.hasFilesWithExtension("..", ".xls")).to.be.false;
+		expect(await context.hasFilesWithExtension("..", ".dts")).to.be.false;
+	});
+
+	it("should return false if the directory doesn't exist", async () => {
+		const context = new MigrationContext(__dirname);
+		expect(await context.hasFilesWithExtension("foo", ".json")).to.be.false;
+		expect(await context.hasFilesWithExtension("../bar", ".ts")).to.be
+			.false;
+	});
+});
+
+describe("hasDevDependency()", () => {
+	it("should return true if the dependency exists", () => {
+		const context = new MigrationContext(__dirname);
+		context.packageJson = {
+			devDependencies: {
+				gulp: "^3.9.1",
+				mocha: "^4.1.0",
+				chai: "^4.1.2",
+			},
+		};
+		expect(context.hasDevDependency("gulp")).to.be.true;
+		expect(context.hasDevDependency("mocha")).to.be.true;
+		expect(context.hasDevDependency("chai")).to.be.true;
+	});
+
+	it("should return false if the dependency doesn't exists", () => {
+		const context = new MigrationContext(__dirname);
+		context.packageJson = {
+			devDependencies: {
+				gulp: "^3.9.1",
+				mocha: "^4.1.0",
+				chai: "^4.1.2",
+			},
+		};
+		expect(context.hasDevDependency("coffee")).to.be.false;
+		expect(context.hasDevDependency("chia")).to.be.false;
+	});
+});
+
+describe("getMainFileContent()", () => {
+	it("should return the contents of the TS file if a main JS file is found with a corresponding TS file", async () => {
+		const baseDir = path.resolve(__dirname, "../..");
+		const context = new MigrationContext(baseDir);
+		context.packageJson = {
+			main: "build/src/cli.js",
+		};
+		expect(await context.getMainFileContent()).not.to.be.empty;
+		expect(await context.getMainFileContent()).to.contain(
+			"import * as yargs",
+		);
+	});
+
+	it("should return the contents of the main file if a main file is found with no corresponding TS file", async () => {
+		const baseDir = path.resolve(__dirname, "../..");
+		const context = new MigrationContext(baseDir);
+		context.packageJson = {
+			main: "bin/create-adapter.js",
+		};
+		expect(await context.getMainFileContent()).not.to.be.empty;
+		expect(await context.getMainFileContent()).to.contain(
+			"#!/usr/bin/env node",
+		);
+	});
+
+	it("should return an empty string if no main file is found", async () => {
+		const baseDir = path.resolve(__dirname, "../..");
+		const context = new MigrationContext(baseDir);
+		context.packageJson = {
+			main: "foo/bar.js",
+		};
+		expect(await context.getMainFileContent()).to.be.empty;
+	});
+});
+
+describe("analyzeCode()", () => {
+	it("should return true the first string occurs more than the second", async () => {
+		const baseDir = path.resolve(__dirname, "../..");
+		const context = new MigrationContext(baseDir);
+		context.packageJson = {
+			main: "build/src/cli.js",
+		};
+		expect(await context.analyzeCode("\t", "  ")).to.be.true;
+		expect(await context.analyzeCode('"', "'")).to.be.true;
+	});
+	it("should return false the first string occurs less often than the second", async () => {
+		const baseDir = path.resolve(__dirname, "../..");
+		const context = new MigrationContext(baseDir);
+		context.packageJson = {
+			main: "build/src/cli.js",
+		};
+		expect(await context.analyzeCode("  ", "\t")).to.be.false;
+		expect(await context.analyzeCode("'", '"')).to.be.false;
+	});
+});

--- a/src/lib/migrationContext.ts
+++ b/src/lib/migrationContext.ts
@@ -29,11 +29,14 @@ export class MigrationContext {
 	public async hasFilesWithExtension(
 		dirName: string,
 		extension: string,
+		filter?: (fileName: string) => boolean,
 	): Promise<boolean> {
 		return (
 			(await this.directoryExists(dirName)) &&
-			!!(await readdir(path.join(this.baseDir, dirName))).find((f) =>
-				f.toLowerCase().endsWith(extension.toLowerCase()),
+			(await readdir(path.join(this.baseDir, dirName))).some(
+				(f) =>
+					(!filter || filter(f)) &&
+					f.toLowerCase().endsWith(extension.toLowerCase()),
 			)
 		);
 	}

--- a/src/lib/migrationContext.ts
+++ b/src/lib/migrationContext.ts
@@ -1,12 +1,12 @@
 import { existsSync, readdir, readFile, readJson, stat } from "fs-extra";
 import path = require("path");
 
-export class ImportContext {
+export class MigrationContext {
 	public packageJson: any;
 	public ioPackageJson: any;
 
 	constructor(private readonly baseDir: string) {
-		console.log(`Importing from ${baseDir}`);
+		console.log(`Migrating from ${baseDir}`);
 	}
 
 	public async load(): Promise<void> {

--- a/src/lib/migrationContext.ts
+++ b/src/lib/migrationContext.ts
@@ -85,14 +85,13 @@ export class MigrationContext {
 				const tsMain = tsMains[i];
 				if (existsSync(tsMain)) {
 					// most probably TypeScript
-					return await readFile(tsMain, { encoding: "utf8" });
+					return readFile(tsMain, { encoding: "utf8" });
 				}
 			}
 
-			return await readFile(
-				path.join(this.baseDir, this.packageJson.main),
-				{ encoding: "utf8" },
-			);
+			return readFile(path.join(this.baseDir, this.packageJson.main), {
+				encoding: "utf8",
+			});
 		} catch {
 			// we don't want this to crash, so just return an empty string
 			return "";

--- a/src/lib/migrationContext.ts
+++ b/src/lib/migrationContext.ts
@@ -39,10 +39,7 @@ export class MigrationContext {
 	}
 
 	public hasDevDependency(packageName: string): boolean {
-		return (
-			this.packageJson.devDependencies &&
-			this.packageJson.devDependencies.hasOwnProperty(packageName)
-		);
+		return this.packageJson.devDependencies?.hasOwnProperty(packageName);
 	}
 
 	public async getMainFileContent(): Promise<string> {

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -495,7 +495,11 @@ export const questionsAndText: (
 					"Which language do you want to use to code the adapter?",
 				choices: ["JavaScript", "TypeScript"],
 				migrate: async (ctx) =>
-					(await ctx.hasFilesWithExtension("src", ".ts"))
+					(await ctx.hasFilesWithExtension(
+						"src",
+						".ts",
+						(f) => !f.endsWith(".d.ts"),
+					))
 						? "TypeScript"
 						: "JavaScript",
 			},
@@ -507,7 +511,18 @@ export const questionsAndText: (
 				initial: "no",
 				choices: ["yes", "no"],
 				migrate: async (ctx) =>
-					(await ctx.directoryExists("admin/src")) ? "yes" : "no",
+					(await ctx.hasFilesWithExtension(
+						"admin/src",
+						".jsx",
+						(f) => !f.endsWith("tab.jsx"),
+					)) ||
+					(await ctx.hasFilesWithExtension(
+						"admin/src",
+						".tsx",
+						(f) => !f.endsWith("tab.tsx"),
+					))
+						? "yes"
+						: "no",
 			},
 			{
 				condition: [{ name: "adminFeatures", contains: "tab" }],

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -470,7 +470,7 @@ export const questionsAndText: (
 				initial: "no",
 				choices: ["yes", "no"],
 				migrate: (ctx) =>
-					ctx.ioPackageJson.instanceObjects?.find(
+					ctx.ioPackageJson.instanceObjects?.some(
 						(o: any) => o._id === "info.connection",
 					)
 						? "yes"

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -15,8 +15,8 @@ import {
 	transformKeywords,
 } from "./actionsAndTransformers";
 import { testCondition } from "./createAdapter";
-import { ImportContext } from "./importContext";
 import { licenses } from "./licenses";
+import { MigrationContext } from "./migrationContext";
 import { getOwnVersion } from "./tools";
 
 // This is being used to simulate wrong options for conditions on the type level
@@ -37,8 +37,8 @@ export type Condition = { name: string } & (
 interface QuestionMeta {
 	/** One or more conditions that need(s) to be fulfilled for this question to be asked */
 	condition?: Condition | Condition[];
-	import?: (
-		context: ImportContext,
+	migrate?: (
+		context: MigrationContext,
 		answers: Record<string, any>,
 		question: Question,
 	) =>
@@ -120,14 +120,14 @@ export const questionsAndText: (
 				message: "Please enter the name of your project:",
 				resultTransform: transformAdapterName,
 				action: checkAdapterName,
-				import: (ctx) => ctx.ioPackageJson.common?.name,
+				migrate: (ctx) => ctx.ioPackageJson.common?.name,
 			},
 			{
 				type: "input",
 				name: "title",
 				message: "Which title should be shown in the admin UI?",
 				action: checkTitle,
-				import: (ctx) =>
+				migrate: (ctx) =>
 					ctx.ioPackageJson.common?.titleLang?.en ||
 					ctx.ioPackageJson.common?.title,
 			},
@@ -138,7 +138,7 @@ export const questionsAndText: (
 				hint: "(optional)",
 				optional: true,
 				resultTransform: transformDescription,
-				import: (ctx) =>
+				migrate: (ctx) =>
 					ctx.ioPackageJson.common?.desc?.en ||
 					ctx.ioPackageJson.common?.desc,
 			},
@@ -150,7 +150,7 @@ export const questionsAndText: (
 				hint: "(optional)",
 				optional: true,
 				resultTransform: transformKeywords,
-				import: (ctx) =>
+				migrate: (ctx) =>
 					(
 						ctx.ioPackageJson.common?.keywords ||
 						ctx.packageJson.common?.keywords ||
@@ -165,7 +165,7 @@ export const questionsAndText: (
 				hint: "(optional)",
 				optional: true,
 				resultTransform: transformContributors,
-				import: (ctx) =>
+				migrate: (ctx) =>
 					(ctx.packageJson.contributors || [])
 						.map((c: Record<string, string>) => c.name)
 						.filter((name: string) => !!name)
@@ -196,7 +196,7 @@ export const questionsAndText: (
 					{ message: "I want to specify everything!", value: "yes" },
 				],
 				optional: true,
-				import: () => "yes", // always force expert mode for import
+				migrate: () => "yes", // always force expert mode for migrate
 			},
 			styledMultiselect({
 				name: "features",
@@ -207,7 +207,7 @@ export const questionsAndText: (
 					{ message: "Visualization", value: "vis" },
 				],
 				action: checkMinSelections.bind(undefined, "feature", 1),
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					[
 						(await ctx.directoryExists("admin")) ? "adapter" : null,
 						(await ctx.directoryExists("widgets")) ? "vis" : null,
@@ -225,7 +225,7 @@ export const questionsAndText: (
 					{ message: "An extra tab", value: "tab" },
 					{ message: "Custom options for states", value: "custom" },
 				],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					[
 						(await ctx.fileExists("admin/tab.html")) ||
 						(await ctx.fileExists("admin/tab_m.html"))
@@ -369,7 +369,7 @@ export const questionsAndText: (
 						value: "weather",
 					},
 				],
-				import: (ctx) => ctx.ioPackageJson.common?.type,
+				migrate: (ctx) => ctx.ioPackageJson.common?.type,
 			},
 			{
 				condition: { name: "features", doesNotContain: "adapter" },
@@ -380,7 +380,7 @@ export const questionsAndText: (
 					{ message: "Icons for VIS", value: "visualization-icons" },
 					{ message: "VIS widgets", value: "visualization-widgets" },
 				],
-				import: (ctx) => ctx.ioPackageJson.common?.type,
+				migrate: (ctx) => ctx.ioPackageJson.common?.type,
 			},
 			{
 				condition: { name: "features", contains: "adapter" },
@@ -406,7 +406,7 @@ export const questionsAndText: (
 					},
 					{ message: "never", value: "none" },
 				],
-				import: (ctx) => ctx.ioPackageJson.common?.mode,
+				migrate: (ctx) => ctx.ioPackageJson.common?.mode,
 			},
 			{
 				condition: { name: "startMode", value: "schedule" },
@@ -417,7 +417,7 @@ export const questionsAndText: (
 					"Should the adapter also be started when the configuration is changed?",
 				initial: "no",
 				choices: ["yes", "no"],
-				import: (ctx) =>
+				migrate: (ctx) =>
 					ctx.ioPackageJson.common?.allowInit ? "yes" : "no",
 			},
 			{
@@ -433,7 +433,7 @@ export const questionsAndText: (
 						value: "local",
 					},
 				],
-				import: (ctx) => ctx.ioPackageJson.common?.connectionType,
+				migrate: (ctx) => ctx.ioPackageJson.common?.connectionType,
 			},
 			{
 				condition: { name: "features", contains: "adapter" },
@@ -458,7 +458,7 @@ export const questionsAndText: (
 						value: "assumption",
 					},
 				],
-				import: (ctx) => ctx.ioPackageJson.common?.dataSource,
+				migrate: (ctx) => ctx.ioPackageJson.common?.dataSource,
 			},
 			{
 				condition: { name: "features", contains: "adapter" },
@@ -469,7 +469,7 @@ export const questionsAndText: (
 				hint: "(To some device or some service)",
 				initial: "no",
 				choices: ["yes", "no"],
-				import: (ctx) =>
+				migrate: (ctx) =>
 					ctx.ioPackageJson.instanceObjects?.find(
 						(o: any) => o._id === "info.connection",
 					)
@@ -494,7 +494,7 @@ export const questionsAndText: (
 				message:
 					"Which language do you want to use to code the adapter?",
 				choices: ["JavaScript", "TypeScript"],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.hasFilesWithExtension("src", ".ts"))
 						? "TypeScript"
 						: "JavaScript",
@@ -506,7 +506,7 @@ export const questionsAndText: (
 				message: "Use React for the Admin UI?",
 				initial: "no",
 				choices: ["yes", "no"],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.directoryExists("admin/src")) ? "yes" : "no",
 			},
 			{
@@ -516,7 +516,7 @@ export const questionsAndText: (
 				message: "Use React for the tab UI?",
 				initial: "no",
 				choices: ["yes", "no"],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.fileExists("admin/src/tab.jsx")) ||
 					(await ctx.fileExists("admin/src/tab.tsx"))
 						? "yes"
@@ -536,7 +536,7 @@ export const questionsAndText: (
 							"(Requires VSCode and Docker, starts a fresh ioBroker in a Docker container with only your adapter installed)",
 					},
 				],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					[
 						ctx.hasDevDependency("eslint") ? "ESLint" : null,
 						ctx.hasDevDependency("typescript")
@@ -567,7 +567,7 @@ export const questionsAndText: (
 					},
 				],
 				action: checkTypeScriptTools,
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					[
 						ctx.hasDevDependency("eslint") ? "ESLint" : null,
 						ctx.hasDevDependency("prettier") ? "Prettier" : null,
@@ -585,7 +585,7 @@ export const questionsAndText: (
 				message: "Do you prefer tab or space indentation?",
 				initial: "Tab",
 				choices: ["Tab", "Space (4)"],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.analyzeCode("\t", "  ")) ? "Tab" : "Space (4)",
 			},
 			{
@@ -595,7 +595,7 @@ export const questionsAndText: (
 				message: "Do you prefer double or single quotes?",
 				initial: "double",
 				choices: ["double", "single"],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.analyzeCode('"', "'")) ? "double" : "single",
 			},
 			{
@@ -617,7 +617,7 @@ export const questionsAndText: (
 						value: "no",
 					},
 				],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.getMainFileContent()).match(/^[ \t]*class/gm)
 						? "yes"
 						: "no",
@@ -632,7 +632,7 @@ export const questionsAndText: (
 				name: "authorName",
 				message: "Please enter your name (or nickname):",
 				action: checkAuthorName,
-				import: (ctx) => ctx.packageJson.author?.name,
+				migrate: (ctx) => ctx.packageJson.author?.name,
 			},
 			{
 				type: "input",
@@ -640,7 +640,7 @@ export const questionsAndText: (
 				message: "What's your name/org on GitHub?",
 				initial: ((answers: Answers) => answers.authorName) as any,
 				action: checkAuthorName,
-				import: (ctx) =>
+				migrate: (ctx) =>
 					ctx.ioPackageJson.common?.extIcon?.replace(
 						/^.+?\.com\/([^\/]+)\/.+$/,
 						"$1",
@@ -651,7 +651,7 @@ export const questionsAndText: (
 				name: "authorEmail",
 				message: "What's your email address?",
 				action: checkEmail,
-				import: (ctx) => ctx.packageJson.author?.email,
+				migrate: (ctx) => ctx.packageJson.author?.email,
 			},
 			{
 				type: "select",
@@ -668,7 +668,7 @@ export const questionsAndText: (
 						hint: "(requires you to setup SSH keys)",
 					},
 				],
-				import: (ctx) =>
+				migrate: (ctx) =>
 					ctx.packageJson.repository?.url?.match(/^git@/)
 						? "SSH"
 						: "HTTPS",
@@ -681,7 +681,7 @@ export const questionsAndText: (
 				message: "Initialize the GitHub repo automatically?",
 				initial: "no",
 				choices: ["yes", "no"],
-				import: () => "no",
+				migrate: () => "no",
 			},
 			{
 				type: "select",
@@ -698,7 +698,7 @@ export const questionsAndText: (
 					"MIT License",
 					"The Unlicense",
 				],
-				import: (ctx) =>
+				migrate: (ctx) =>
 					Object.keys(licenses).find(
 						(k) => licenses[k].id === ctx.packageJson.license,
 					),
@@ -719,7 +719,7 @@ export const questionsAndText: (
 						value: "travis",
 					},
 				],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.fileExists(".travis.yml")) &&
 					!(await ctx.directoryExists(".github/workflows"))
 						? "travis"
@@ -734,7 +734,7 @@ export const questionsAndText: (
 				hint: "(recommended)",
 				initial: "no",
 				choices: ["yes", "no"],
-				import: async (ctx) =>
+				migrate: async (ctx) =>
 					(await ctx.fileExists(".github/dependabot.yml"))
 						? "yes"
 						: "no",


### PR DESCRIPTION
**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [x] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [x] Run the test suite with `npm test`
-   [ ] ~~If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes~~
-   [x] Ensure the project builds with `npm run build`
-   [ ] ~~If you added a required option, also add it to the template creation (`.github/create_templates.ts`)~~
-   [ ] ~~Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project~~
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
Allow to run the adapter creator with the answers pre-filled from an existing adapter directory (the given path needs to point to the adapter base directory where `io-package.json` is found). It will try to pre-fill all answers, but the user still has to acknowledge all answers.
