### PR TITLE
fix: remove the base_ref check from the release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -61,11 +61,10 @@ jobs:
 
   # Deploys the final package to NPM and Github Releases
   deploy:
-    # Trigger this step only when a commit on master is tagged with a version number
+    # Trigger this step only when a commit is tagged with a version number
     if: |
       contains(github.event.head_commit.message, '[skip ci]') == false &&
       github.event_name == 'push' &&
-      github.event.base_ref == 'refs/heads/master' &&
       startsWith(github.ref, 'refs/tags/v')
 
     needs: [unit-tests]


### PR DESCRIPTION
We already removed it from the generated adapter, but forgot our own release workflow.