### PR TITLE
fix: add common.title property back to io-package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 -->
 ## __WORK IN PROGRESS__
 * (AlCalzone) Require Node.js 12+ to execute the creator (#767)
+* (AlCalzone) Add `common.title` property back into `io-package.json` (#796)
 
 ## 1.34.1 (2021-07-07)
 * (UncleSamSwiss) Fix missing `common.main` in `io-package.json` (#778)

--- a/templates/io-package.json.ts
+++ b/templates/io-package.json.ts
@@ -54,6 +54,7 @@ export = (async answers => {
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "${title}",
 		"titleLang": ${titleLang},
 		"desc": ${descriptionLang},
 		"authors": [

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/io-package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/io-package.json
@@ -16,6 +16,7 @@
                 "zh-cn": "首次出版"
             }
         },
+        "title": "Is used to test the creator",
         "titleLang": {
             "en": "Mock translation of 'Is used to test the creator' to 'en'",
             "de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/io-package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/io-package.json
@@ -16,6 +16,7 @@
                 "zh-cn": "首次出版"
             }
         },
+        "title": "Is used to test the creator",
         "titleLang": {
             "en": "Mock translation of 'Is used to test the creator' to 'en'",
             "de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/adapter_JS_React/io-package.json
+++ b/test/baselines/adapter_JS_React/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/io-package.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/io-package.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/adapter_TS_React/io-package.json
+++ b/test/baselines/adapter_TS_React/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/connectionIndicator_yes/io-package.json
+++ b/test/baselines/connectionIndicator_yes/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/connectionType/io-package.json
+++ b/test/baselines/connectionType/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/customAdapterSettings/io-package.json
+++ b/test/baselines/customAdapterSettings/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/description_empty_1/io-package.json
+++ b/test/baselines/description_empty_1/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/description_empty_2/io-package.json
+++ b/test/baselines/description_empty_2/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/description_valid/io-package.json
+++ b/test/baselines/description_valid/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/keywords/io-package.json
+++ b/test/baselines/keywords/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/startMode_schedule/io-package.json
+++ b/test/baselines/startMode_schedule/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/type_storage/io-package.json
+++ b/test/baselines/type_storage/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/type_visualization-icons/io-package.json
+++ b/test/baselines/type_visualization-icons/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/vis_Widget/io-package.json
+++ b/test/baselines/vis_Widget/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",

--- a/test/baselines/vis_Widget_Travis/io-package.json
+++ b/test/baselines/vis_Widget_Travis/io-package.json
@@ -16,6 +16,7 @@
 				"zh-cn": "首次出版"
 			}
 		},
+		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Mock translation of 'Is used to test the creator' to 'en'",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] ~~If you added a required option, also add it to the template creation (`.github/create_templates.ts`)~~
-   [ ] ~~Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project~~ not necessary
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
When we started checking `io-package.json` against the template, it was missing the `title` property, so we removed it. Turns out this is not yet ok (Admin 4).

fixes: #795 
