### PR TITLE
ci: only test on "master" and in PRs

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,7 +5,7 @@ name: Test and Release
 on:
   push:
     branches:
-      - "*"
+      - master
     tags:
       # normal versions
       - "v[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
I don't think we can do this in the templates because we don't know how the default branch is named.

fixes: #768