### PR TITLE
Modernize TSConfig, require Node 12.20 for ESM support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
+build/
 test/baselines/
+.eslintrc.js
+.prettierrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	parser: "@typescript-eslint/parser", // Specifies the ESLint parser
 	parserOptions: {
-		ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+		ecmaVersion: 2019, // Allows for the parsing of modern ECMAScript features
 		sourceType: "module", // Allows for the use of imports
 		project: "./tsconfig.json",
 	},

--- a/.github/create_pullrequest.ts
+++ b/.github/create_pullrequest.ts
@@ -25,7 +25,7 @@ const options: AxiosRequestConfig = {
 				base: "master",
 			},
 		});
-	} catch (e) {
+	} catch (e: any) {
 		createPrResponse = e.response;
 		console.error(
 			red(`PR creation failed with code ${createPrResponse.status}:

--- a/.github/create_templates.ts
+++ b/.github/create_templates.ts
@@ -3,7 +3,7 @@ import { execSync, ExecSyncOptions } from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
 import { createAdapter } from "../src";
-import { Answers } from "../src/lib/core/questions";
+import type { Answers } from "../src/lib/core/questions";
 import { writeFiles } from "../src/lib/createAdapter";
 
 const outDir = path.join(process.cwd(), "ioBroker.template");

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 AlCalzone
+Copyright (c) 2018-2021 AlCalzone
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/maintenance/cacheLicenses.ts
+++ b/maintenance/cacheLicenses.ts
@@ -5,7 +5,7 @@ import axios, { AxiosRequestConfig } from "axios";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as yargs from "yargs";
-import { License } from "../src/lib/core/licenses";
+import type { License } from "../src/lib/core/licenses";
 import { applyHttpsProxy, getRequestTimeout } from "../src/lib/tools";
 
 // Taken from https://api.github.com/licenses

--- a/maintenance/generateTemplateIndex.ts
+++ b/maintenance/generateTemplateIndex.ts
@@ -41,7 +41,7 @@ const indexContent = `
 // and contains references to all defined templates.
 // Do not edit it by hand or your changes will be lost!
 
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templates: { name: string, templateFunction: TemplateFunction }[] = [
 ${templatePaths.join(os.EOL)}

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "url": "https://github.com/ioBroker/create-adapter/issues"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12.20"
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
     "@alcalzone/release-script": "^1.10.0",
+    "@tsconfig/node12": "^1.0.9",
     "@types/ansi-colors": "^3.2.2",
     "@types/chai": "^4.2.19",
     "@types/chai-as-promised": "^7.1.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,8 @@ import { prompt } from "enquirer";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as yargs from "yargs";
-import { CheckResult } from "./lib/core/actionsAndTransformers";
-import { MigrationContextBase } from "./lib/core/migrationContextBase";
+import type { CheckResult } from "./lib/core/actionsAndTransformers";
+import type { MigrationContextBase } from "./lib/core/migrationContextBase";
 import {
 	Answers,
 	Question,

--- a/src/lib/core/actionsAndTransformers.ts
+++ b/src/lib/core/actionsAndTransformers.ts
@@ -1,5 +1,5 @@
 import { yellow } from "ansi-colors";
-import { Answers } from "./questions";
+import type { Answers } from "./questions";
 
 const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 

--- a/src/lib/core/questions.ts
+++ b/src/lib/core/questions.ts
@@ -1,6 +1,6 @@
 import { isArray } from "alcalzone-shared/typeguards";
 import { dim, gray, green } from "ansi-colors";
-import { SpecificPromptOptions } from "enquirer";
+import type { SpecificPromptOptions } from "enquirer";
 import {
 	checkAdapterName,
 	checkAuthorName,
@@ -15,7 +15,7 @@ import {
 	transformKeywords,
 } from "./actionsAndTransformers";
 import { licenses } from "./licenses";
-import { MigrationContextBase } from "./migrationContextBase";
+import type { MigrationContextBase } from "./migrationContextBase";
 
 // This is being used to simulate wrong options for conditions on the type level
 const __misused: unique symbol = Symbol.for("__misused");

--- a/src/lib/createAdapter.ts
+++ b/src/lib/createAdapter.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
-import * as templateFiles from "../../templates";
-import { Answers } from "./core/questions";
+import templateFiles from "../../templates";
+import type { Answers } from "./core/questions";
 import {
 	formatWithPrettier,
 	getOwnVersion,

--- a/src/lib/packageVersions.test.ts
+++ b/src/lib/packageVersions.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import * as proxyquireModule from "proxyquire";
+import proxyquireModule from "proxyquire";
 import { stub } from "sinon";
 import { getPackageName, getVersionSpecifier } from "./packageVersions";
 
@@ -9,9 +9,7 @@ const proxyquire = proxyquireModule.noPreserveCache();
 const { fetchPackageVersion, fetchPackageReferenceVersion } = proxyquire<
 	typeof import("./packageVersions")
 >("./packageVersions", {
-	axios: {
-		default: axiosMock,
-	},
+	axios: axiosMock,
 });
 
 function returnVersions(versions: string[]) {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -9,8 +9,9 @@ import * as JSON5 from "json5";
 import * as os from "os";
 import * as path from "path";
 import * as prettier from "prettier";
+import { URL } from "url";
 import { licenses } from "./core/licenses";
-import { Answers } from "./core/questions";
+import type { Answers } from "./core/questions";
 
 export function error(message: string): void {
 	console.error(bold.red(message));

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, Answers, getDefaultAnswer } from "./core/questions";
-import { TemplateFunction } from "./createAdapter";
+import type { TemplateFunction } from "./createAdapter";
 import { formatJsonString, translateText } from "./tools";
 
 export type Languages =

--- a/templates/LICENSE.ts
+++ b/templates/LICENSE.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 import { getFormattedLicense } from "../src/lib/tools";
 
 export = (answers => {

--- a/templates/README.md.ts
+++ b/templates/README.md.ts
@@ -1,5 +1,5 @@
 import { getIconName } from "../src/lib/core/questions";
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 import { getFormattedLicense } from "../src/lib/tools";
 
 export = (answers => {

--- a/templates/_babelrc.ts
+++ b/templates/_babelrc.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_create-adapter.json.ts
+++ b/templates/_create-adapter.json.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/README.md.ts
+++ b/templates/_devcontainer/README.md.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/devcontainer.json.ts
+++ b/templates/_devcontainer/devcontainer.json.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/docker-compose.yml.ts
+++ b/templates/_devcontainer/docker-compose.yml.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/iobroker/_Dockerfile.ts
+++ b/templates/_devcontainer/iobroker/_Dockerfile.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/nginx/nginx.conf.ts
+++ b/templates/_devcontainer/nginx/nginx.conf.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/parcel/_Dockerfile.ts
+++ b/templates/_devcontainer/parcel/_Dockerfile.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_devcontainer/parcel/run.sh.ts
+++ b/templates/_devcontainer/parcel/run.sh.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_eslintignore.ts
+++ b/templates/_eslintignore.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_eslintrc_javascript.json.ts
+++ b/templates/_eslintrc_javascript.json.ts
@@ -1,5 +1,5 @@
 import * as JSON5 from "json5";
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_eslintrc_typescript.js.ts
+++ b/templates/_eslintrc_typescript.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_github/dependabot.yml.ts
+++ b/templates/_github/dependabot.yml.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_github/workflows/test-and-release.yml.ts
+++ b/templates/_github/workflows/test-and-release.yml.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_gitignore.ts
+++ b/templates/_gitignore.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_npmignore.ts
+++ b/templates/_npmignore.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_prettierignore.ts
+++ b/templates/_prettierignore.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_prettierrc.js.ts
+++ b/templates/_prettierrc.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_vscode/extensions.json.ts
+++ b/templates/_vscode/extensions.json.ts
@@ -1,5 +1,5 @@
 import * as JSON5 from "json5";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/_vscode/settings.json.ts
+++ b/templates/_vscode/settings.json.ts
@@ -1,5 +1,5 @@
 import * as JSON5 from "json5";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/admin/custom_m.html.ts
+++ b/templates/admin/custom_m.html.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 export = (answers => {
 

--- a/templates/admin/index_m.html.ts
+++ b/templates/admin/index_m.html.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer, getIconName } from "../../src/lib/core/questions";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 function generateSettingsDiv(settings: AdapterSettings): string {
 	if (settings.inputType === "select" && settings.options) {

--- a/templates/admin/src/app.tsx_jsx.ts
+++ b/templates/admin/src/app.tsx_jsx.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/admin/src/components/settings.tsx_jsx.ts
+++ b/templates/admin/src/components/settings.tsx_jsx.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer } from "../../../../src/lib/core/questions";
-import { TemplateFunction } from "../../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../../src/lib/createAdapter";
 
 function generateSettingsMethod(settings: AdapterSettings): string {
 	if (settings.inputType === "select" && settings.options) {

--- a/templates/admin/src/i18n/i18n.d.ts.ts
+++ b/templates/admin/src/i18n/i18n.d.ts.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/admin/src/index.tsx_jsx.ts
+++ b/templates/admin/src/index.tsx_jsx.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/admin/src/tab-app.tsx_jsx.ts
+++ b/templates/admin/src/tab-app.tsx_jsx.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/admin/src/tab.tsx_jsx.ts
+++ b/templates/admin/src/tab.tsx_jsx.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/admin/tab_m.html.ts
+++ b/templates/admin/tab_m.html.ts
@@ -1,5 +1,5 @@
 import { getIconName } from "../../src/lib/core/questions";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 export = (answers => {
 

--- a/templates/admin/words.js.ts
+++ b/templates/admin/words.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 import { formatJsonString } from "../../src/lib/tools";
 import { getTranslatedSettings } from "../../src/lib/translation";
 

--- a/templates/gulpfile.js.ts
+++ b/templates/gulpfile.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 export = (answers => {
 

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -2,7 +2,7 @@
 // and contains references to all defined templates.
 // Do not edit it by hand or your changes will be lost!
 
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 const templates: { name: string, templateFunction: TemplateFunction }[] = [
 	{ name: "_babelrc.ts", templateFunction: require("./_babelrc") },

--- a/templates/io-package.json.ts
+++ b/templates/io-package.json.ts
@@ -2,7 +2,7 @@ import { composeObject } from "alcalzone-shared/objects";
 import * as JSON5 from "json5";
 import { licenses } from "../src/lib/core/licenses";
 import { AdapterSettings, getDefaultAnswer, getIconName } from "../src/lib/core/questions";
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 import { translateText } from "../src/lib/tools";
 
 export = (async answers => {

--- a/templates/lib/adapter-config.d.ts.ts
+++ b/templates/lib/adapter-config.d.ts.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer } from "../../src/lib/core/questions";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 function generateSettingsProperty(settings: AdapterSettings): string {
 	if (settings.inputType === "select" && settings.options) {

--- a/templates/main.es6.js.ts
+++ b/templates/main.es6.js.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer } from "../src/lib/core/questions";
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 import { kebabCaseToUpperCamelCase } from "../src/lib/tools";
 
 const templateFunction: TemplateFunction = async answers => {

--- a/templates/main.js.ts
+++ b/templates/main.js.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer } from "../src/lib/core/questions";
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 export = (async answers => {
 

--- a/templates/package.json.ts
+++ b/templates/package.json.ts
@@ -1,8 +1,8 @@
 import * as JSON5 from "json5";
-import * as pLimit from "p-limit";
+import pLimit from "p-limit";
 import { licenses } from "../src/lib/core/licenses";
 import { getDefaultAnswer } from "../src/lib/core/questions";
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 import { fetchPackageReferenceVersion, getPackageName } from "../src/lib/packageVersions";
 
 // Limit package version downloads to 10 simultaneous connections

--- a/templates/src/main.es6.ts
+++ b/templates/src/main.es6.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer } from "../../src/lib/core/questions";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 import { kebabCaseToUpperCamelCase } from "../../src/lib/tools";
 
 const templateFunction: TemplateFunction = async answers => {

--- a/templates/src/main.ts.ts
+++ b/templates/src/main.ts.ts
@@ -1,5 +1,5 @@
 import { AdapterSettings, getDefaultAnswer } from "../../src/lib/core/questions";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 export = (answers => {
 

--- a/templates/test/integration.js.ts
+++ b/templates/test/integration.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/test/mocha.setup.js.ts
+++ b/templates/test/mocha.setup.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 export = (answers => {
 

--- a/templates/test/mocharc.custom.ts
+++ b/templates/test/mocharc.custom.ts
@@ -1,5 +1,5 @@
 import * as JSON5 from "json5";
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/tsconfig.json.ts
+++ b/templates/tsconfig.json.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../src/lib/createAdapter";
+import type { TemplateFunction } from "../src/lib/createAdapter";
 
 export = (answers => {
 

--- a/templates/widgets/style.css.ts
+++ b/templates/widgets/style.css.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/widgets/template.html.ts
+++ b/templates/widgets/template.html.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/templates/widgets/template.js.ts
+++ b/templates/widgets/template.js.ts
@@ -1,4 +1,4 @@
-import { TemplateFunction } from "../../src/lib/createAdapter";
+import type { TemplateFunction } from "../../src/lib/createAdapter";
 
 const templateFunction: TemplateFunction = answers => {
 

--- a/test/baselines/TS_SingleQuotes/.eslintignore
+++ b/test/baselines/TS_SingleQuotes/.eslintignore
@@ -1,2 +1,3 @@
+admin/build/
 build/
 **/.eslintrc.js

--- a/test/create-adapter.test.ts
+++ b/test/create-adapter.test.ts
@@ -6,7 +6,7 @@ import * as fs from "fs-extra";
 import { validate as validateJSON } from "jsonschema";
 import * as path from "path";
 import { createAdapter } from "../src/index";
-import { Answers } from "../src/lib/core/questions";
+import type { Answers } from "../src/lib/core/questions";
 import { File, writeFiles } from "../src/lib/createAdapter";
 
 const baselineDir = path.join(__dirname, "../test/baselines");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,26 +8,30 @@
 		"noEmit": true,
 		// Never emit faulty JS
 		"noEmitOnError": true,
-
 		"outDir": "./build/",
 		"removeComments": false,
-
 		// Avoid runtime imports that are unnecessary
 		"importsNotUsedAsValues": "error",
-
 		// The way we use `enquirer` is incompatible with strictFunctionTypes
 		"strictFunctionTypes": false,
-
 		// We import some .json files and TS should pick them up correctly
 		"resolveJsonModule": true,
-
 		// Required for TS debugging
 		"sourceMap": true,
 		"inlineSourceMap": false,
-
 		// Fix enquirer typings
-		"typeRoots": ["./src/@types", "./node_modules/@types"]
+		"typeRoots": [
+			"./src/@types",
+			"./node_modules/@types"
+		]
 	},
-	"include": ["**/*.ts"],
-	"exclude": ["build/**", "node_modules/**", "test/baselines/**"]
+	"include": [
+		"**/*.ts",
+		".github/*.ts"
+	],
+	"exclude": [
+		"build/**",
+		"node_modules/**",
+		"test/baselines/**"
+	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,32 @@
 {
-	"compileOnSave": true,
+	// To update the compilation target, install a different version of @tsconfig/node... and reference it here
+	// https://github.com/tsconfig/bases#node-12-tsconfigjson
+	"extends": "@tsconfig/node12/tsconfig.json",
 	"compilerOptions": {
+		// do not compile anything, this file is just to configure type checking
+		// the compilation is configured in tsconfig.build.json
 		"noEmit": true,
+		// Never emit faulty JS
 		"noEmitOnError": true,
-		"module": "commonjs",
-		"moduleResolution": "node",
+
 		"outDir": "./build/",
 		"removeComments": false,
-		"strict": true,
+
+		// Avoid runtime imports that are unnecessary
+		"importsNotUsedAsValues": "error",
+
+		// The way we use `enquirer` is incompatible with strictFunctionTypes
 		"strictFunctionTypes": false,
+
+		// We import some .json files and TS should pick them up correctly
 		"resolveJsonModule": true,
+
+		// Required for TS debugging
 		"sourceMap": true,
 		"inlineSourceMap": false,
-		"target": "es2017",
-		"watch": false,
+
 		// Fix enquirer typings
-		"typeRoots": ["./src/@types/", "./node_modules/@types"]
+		"typeRoots": ["./src/@types", "./node_modules/@types"]
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["build/**", "node_modules/**", "test/baselines/**"]


### PR DESCRIPTION
As part of #757, the creator itself now requires Node 12.20 for full ESM support. To simplify configuration, I've changed the tsconfig to extend `@tsconfig/bases` where we just need to install the correct template for the Node version we want to target (currently Node 12). This does not affect the generated adapters, which still support Node 10.

I've taken the chance to modernize the tsconfig a bit and avoid runtime imports when we only import types.