### PR TITLE
Set eraseOnUpload to true for React adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 	## __WORK IN PROGRESS__
 	(at the beginning of a new line )
 -->
+## __WORK IN PROGRESS__
+* (UncleSamSwiss) Setting `eraseOnUpload` to `true` for React adapters (#886) · [Migration guide](docs/updates/20220301_erase_on_upload.md)
+
 ## 2.1.0 (2022-02-16)
 * (UncleSamSwiss) Switched from `gulp` to `@iobroker/adapter-dev` (#839) · [Migration guide](docs/updates/20211018_adapter-dev.md)
 * (AlCalzone) Switch build process (React, TypeScript) from `parcel` to `@iobroker/adapter-dev` using `esbuild` (#838) · [Migration guide](docs/updates/20220215_esbuild.md)

--- a/docs/updates/20220301_erase_on_upload.md
+++ b/docs/updates/20220301_erase_on_upload.md
@@ -2,7 +2,7 @@
 
 Since `@iobroker/adapter-dev` version 1.1.0 the output from `npm run build` might be split into multiple output files with random names.
 
-As `ioBroker.js-controller` with versions below 4.1 will not erase old files on upload, new adapter versions might upload more and more files to the `admin` directory.
+Since all available `ioBroker.js-controller` versions do not erase old files on upload, new adapter versions might upload more and more files to the `admin` directory.
 
 Therefore, you should explicitly set `common.eraseOnUpload` in `io-package.json` to `true` for React adapters.
 

--- a/docs/updates/20220301_erase_on_upload.md
+++ b/docs/updates/20220301_erase_on_upload.md
@@ -1,0 +1,22 @@
+# Set `eraseOnUpload` to `true` for React adapters
+
+Since `@iobroker/adapter-dev` version 1.1.0 the output from `npm run build` might be split into multiple output files with random names.
+
+As `ioBroker.js-controller` with versions below 4.1 will not erase old files on upload, new adapter versions might upload more and more files to the `admin` directory.
+
+Therefore, you should explicitly set `common.eraseOnUpload` in `io-package.json` to `true` for React adapters.
+
+```diff
+ {
+     "common": {
+         // other properties ...
+         "connectionType": "local",
+         "dataSource": "push",
+         "materialize": true,
++        "eraseOnUpload": true,
+         "dependencies": [
+             {
+                 "js-controller": ">=2.0.0"
+```
+
+See also https://github.com/ioBroker/adapter-dev/pull/116 for more details.

--- a/templates/io-package.json.ts
+++ b/templates/io-package.json.ts
@@ -10,6 +10,9 @@ export = (async answers => {
 	const isAdapter = answers.features.indexOf("adapter") > -1;
 	const isWidget = answers.features.indexOf("vis") > -1;
 	const useTypeScript = answers.language === "TypeScript";
+	const useAdminReact = answers.adminReact === "yes";
+	const useTabReact = answers.tabReact === "yes";
+	const useReact = useAdminReact || useTabReact;
 	const supportCustom = answers.adminFeatures && answers.adminFeatures.indexOf("custom") > -1;
 	const supportTab = answers.adminFeatures && answers.adminFeatures.indexOf("tab") > -1;
 	const defaultBranch = answers.defaultBranch || "main";
@@ -105,6 +108,7 @@ export = (async answers => {
 		},
 		`) : ""}
 		${supportCustom ? `"supportCustoms": true,` : ""}
+		${useReact ? `"eraseOnUpload": true,` : ""}
 		"dependencies": [
 			${isAdapter ? `{ "js-controller": ">=2.0.0" },` : ""}
 			${isWidget ? `"vis",` : ""}

--- a/test/baselines/TS_Prettier/package.json
+++ b/test/baselines/TS_Prettier/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -31,14 +31,14 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint": "^8.10.0",
+    "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "mocha": "^9.2.0",
+    "mocha": "^9.2.1",
     "prettier": "^2.5.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",

--- a/test/baselines/TS_SingleQuotes/src/main.ts
+++ b/test/baselines/TS_SingleQuotes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
@@ -31,5 +31,5 @@
     "gitCommit": "no",
     "defaultBranch": "main",
     "license": "Apache License 2.0",
-    "creatorVersion": "2.0.2"
+    "creatorVersion": "2.1.0"
 }

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/package.json
+++ b/test/baselines/adapter_JS_ES6Class_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -33,8 +33,8 @@
     "@types/sinon-chai": "^3.2.8",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "sinon": "^13.0.1",
     "sinon-chai": "^3.7.0",

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/.create-adapter.json
@@ -31,5 +31,5 @@
     "gitCommit": "no",
     "defaultBranch": "main",
     "license": "Apache License 2.0",
-    "creatorVersion": "2.0.2"
+    "creatorVersion": "2.1.0"
 }

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/package.json
+++ b/test/baselines/adapter_JS_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -33,8 +33,8 @@
     "@types/sinon-chai": "^3.2.8",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "sinon": "^13.0.1",
     "sinon-chai": "^3.7.0",

--- a/test/baselines/adapter_JS_React/.create-adapter.json
+++ b/test/baselines/adapter_JS_React/.create-adapter.json
@@ -30,5 +30,5 @@
 	"gitCommit": "no",
 	"defaultBranch": "main",
 	"license": "MIT License",
-	"creatorVersion": "2.0.2"
+	"creatorVersion": "2.1.0"
 }

--- a/test/baselines/adapter_JS_React/io-package.json
+++ b/test/baselines/adapter_JS_React/io-package.json
@@ -64,6 +64,7 @@
 		"connectionType": "local",
 		"dataSource": "push",
 		"materialize": true,
+		"eraseOnUpload": true,
 		"dependencies": [
 			{
 				"js-controller": ">=2.0.0"

--- a/test/baselines/adapter_JS_React/main.js
+++ b/test/baselines/adapter_JS_React/main.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_JS_React/package.json
+++ b/test/baselines/adapter_JS_React/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -28,9 +28,9 @@
     "@material-ui/core": "^4.12.3",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "eslint-plugin-react": "^7.28.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "eslint-plugin-react": "^7.29.2",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
@@ -30,5 +30,5 @@
 	"gitCommit": "no",
 	"defaultBranch": "main",
 	"license": "MIT License",
-	"creatorVersion": "2.0.2"
+	"creatorVersion": "2.1.0"
 }

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -31,12 +31,12 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",

--- a/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ES6Class_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/.create-adapter.json
@@ -33,5 +33,5 @@
 	"gitCommit": "no",
 	"defaultBranch": "main",
 	"license": "MIT License",
-	"creatorVersion": "2.0.2"
+	"creatorVersion": "2.1.0"
 }

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -31,12 +31,12 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/adapter_TS_React/.create-adapter.json
+++ b/test/baselines/adapter_TS_React/.create-adapter.json
@@ -30,5 +30,5 @@
 	"gitCommit": "no",
 	"defaultBranch": "main",
 	"license": "MIT License",
-	"creatorVersion": "2.0.2"
+	"creatorVersion": "2.1.0"
 }

--- a/test/baselines/adapter_TS_React/io-package.json
+++ b/test/baselines/adapter_TS_React/io-package.json
@@ -64,6 +64,7 @@
 		"connectionType": "local",
 		"dataSource": "push",
 		"materialize": true,
+		"eraseOnUpload": true,
 		"dependencies": [
 			{
 				"js-controller": ">=2.0.0"

--- a/test/baselines/adapter_TS_React/package.json
+++ b/test/baselines/adapter_TS_React/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -35,13 +35,13 @@
     "@types/react-dom": "^17.0.11",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "eslint-plugin-react": "^7.28.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "eslint-plugin-react": "^7.29.2",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/test/baselines/adapter_TS_React/src/main.ts
+++ b/test/baselines/adapter_TS_React/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/connectionIndicator_yes/src/main.ts
+++ b/test/baselines/connectionIndicator_yes/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/contributors/package.json
+++ b/test/baselines/contributors/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -39,12 +39,12 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",

--- a/test/baselines/customAdapterSettings/src/main.ts
+++ b/test/baselines/customAdapterSettings/src/main.ts
@@ -1,5 +1,5 @@
 /*
- * Created with @iobroker/create-adapter v2.0.2
+ * Created with @iobroker/create-adapter v2.1.0
  */
 
 // The adapter-core module gives you access to the core ioBroker functions

--- a/test/baselines/git_SSH/package.json
+++ b/test/baselines/git_SSH/package.json
@@ -19,7 +19,7 @@
     "url": "git@github.com:AlCalzone/ioBroker.test-adapter.git"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -31,12 +31,12 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",

--- a/test/baselines/keywords/package.json
+++ b/test/baselines/keywords/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.0.0",
@@ -32,12 +32,12 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",

--- a/test/baselines/releaseScript/package.json
+++ b/test/baselines/releaseScript/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/AlCalzone/ioBroker.test-adapter"
   },
   "dependencies": {
-    "@iobroker/adapter-core": "^2.5.1"
+    "@iobroker/adapter-core": "^2.6.0"
   },
   "devDependencies": {
     "@alcalzone/release-script": "^2.2.2",
@@ -32,12 +32,12 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
-    "@typescript-eslint/eslint-plugin": "^5.12.0",
-    "@typescript-eslint/parser": "^5.12.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
+    "@typescript-eslint/parser": "^5.13.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.9.0",
-    "mocha": "^9.2.0",
+    "eslint": "^8.10.0",
+    "mocha": "^9.2.1",
     "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.1",

--- a/test/baselines/vis_Widget/.create-adapter.json
+++ b/test/baselines/vis_Widget/.create-adapter.json
@@ -18,5 +18,5 @@
 	"gitCommit": "no",
 	"defaultBranch": "main",
 	"license": "MIT License",
-	"creatorVersion": "2.0.2"
+	"creatorVersion": "2.1.0"
 }


### PR DESCRIPTION
**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [x] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
Since `@iobroker/adapter-dev` version 1.1.0 the output from `npm run build` might be split into multiple output files with random names. Therefore, we preemptively set `common.eraseOnUpload` in `io-package.json` to `true` for React adapters.