### PR TITLE
replace ESM-only deps with hybrid variants from @esm2cjs org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * (AlCalzone) Cancel previous PR/branch runs when a new commit is pushed (#915) · [Migration guide](docs/updates/20220515_cancel_check_runs.md)
 * (UncleSamSwiss) Add support for JSON Config UI (#724)
 * (crycode-de) Fix `npm run check` for TS-React adapters · [Migration guide](docs/updates/20220608_check_ts_react.md)
+* (AlCalzone) Replace ESM-only dependencies (#943)
 
 ## 2.1.1 (2022-04-01)
 * (UncleSamSwiss) Setting `eraseOnUpload` to `true` for React adapters (#886) · [Migration guide](docs/updates/20220301_erase_on_upload.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
+        "@esm2cjs/p-limit": "^4.0.0",
         "@iobroker/adapter-dev": "^1.0.0",
         "@typescript-eslint/parser": "^5.23.0",
         "alcalzone-shared": "^4.0.1",
@@ -19,7 +20,6 @@
         "eslint": "^8.20.0",
         "fs-extra": "^10.1.0",
         "json5": "^2.2.1",
-        "p-limit": "^3.1.0",
         "prettier": "^2.6.2",
         "semver": "^7.3.7",
         "typescript": "~4.6.4",
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@alcalzone/release-script": "^3.5.9",
+        "@esm2cjs/execa": "^6.1.1-cjs.1",
         "@tsconfig/node12": "^1.0.11",
         "@types/ansi-colors": "^3.2.2",
         "@types/chai": "^4.3.1",
@@ -52,7 +53,6 @@
         "copyfiles": "^2.4.1",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "execa": "^5.1.1",
         "jsonschema": "^1.4.1",
         "mocha": "^10.0.0",
         "proxyquire": "^2.1.3",
@@ -227,6 +227,144 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@esm2cjs/execa": {
+      "version": "6.1.1-cjs.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/execa/-/execa-6.1.1-cjs.1.tgz",
+      "integrity": "sha512-FHxfnmuDIjY1VS/BLzDkL8EkbcFvi8s6x1nYQ1Nyu0An0n88EJcGhDBcRWLFwt3C3nT7xwI+MwHRH1TZcAFW2w==",
+      "dev": true,
+      "dependencies": {
+        "@esm2cjs/human-signals": "^3.0.1",
+        "@esm2cjs/is-stream": "^3.0.0",
+        "@esm2cjs/npm-run-path": "^5.1.1-cjs.0",
+        "@esm2cjs/onetime": "^6.0.1-cjs.0",
+        "@esm2cjs/strip-final-newline": "^3.0.1-cjs.0",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "merge-stream": "^2.0.0",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-QZme4eF/PwTpeSbMB4AaWGQ4VSygzE30jI+Oas1NPTtZQAgcHwWVDOQpIW8FUmtzn5Q+2cS7AjnTzbtqtc5P6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-qcBscHlJpZFOD5nnmMHkzOrq2xyvsp9fbVreQLS8x2LOs8N3CrNi3fqvFY0GVJR+YSOHscwhG9T5t4Ck7R7QGw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-LIIAjcpjLr4rcbYmRQ+eRu55Upy/MMB78seIlwqbnyiA+cTa1/pxWnJ1NHJQrw6tx2wMQmlYoJj+wf16NjWH6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/npm-run-path": {
+      "version": "5.1.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/npm-run-path/-/npm-run-path-5.1.1-cjs.0.tgz",
+      "integrity": "sha512-CWeAIyE8iNSCgP2ItPE8iPgS+lACqgH+MuFRaWOIl2T7hnHqPFfhAJJ/LcLJJ/RMIxNMeenjFMwc91HW7NWr1A==",
+      "dev": true,
+      "dependencies": {
+        "@esm2cjs/path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/onetime": {
+      "version": "6.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/onetime/-/onetime-6.0.1-cjs.0.tgz",
+      "integrity": "sha512-MkZMZSxrSC/6yUuAw6Azc56XOgwHQQIsNDlO/zgFmOcycJBhRwRuc/gdYUUOFNZIh7y+f0JSIxkNdJPFvJ5W0w==",
+      "dev": true,
+      "dependencies": {
+        "@esm2cjs/mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-t2YIlQHsgMy8vyC8oSxIyGuhc99KPjjPI808IENcvWaKWlFEANu8VEO3tMN9jqaqJQp/WpLx+SLqm3vC6Ve9pQ==",
+      "dependencies": {
+        "@esm2cjs/yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-fKzZ3uIIP4j+7WfyG0MEkomGHL0hUXWCx1kY2Zct3GTdl4pyY+3k5lCUxjgdDa2Ld1BCjMNorXnRHiBP6jW6CQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/strip-final-newline": {
+      "version": "3.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/strip-final-newline/-/strip-final-newline-3.0.1-cjs.0.tgz",
+      "integrity": "sha512-o41riCGPiOEStayoikBCAqwa6igbv9L9rP+k5UCfQ24EJD/wGrdDs/KTNwkHG5JzDK3T60D5dMkWkLKEPy8gjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
+      }
+    },
+    "node_modules/@esm2cjs/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-bDqljAQBEJji4mZ4uuH27Zhr5OOoB6YWe/ccG8lt2ZTwZAeOAoS3wugsGQzVUZcxkBYonbXqi/1+rizbuU833A==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/AlCalzone"
       }
     },
     "node_modules/@google-cloud/common": {
@@ -2258,11 +2396,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3461,6 +3594,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3853,6 +3987,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sinon": {
       "version": "14.0.0",
@@ -4445,6 +4584,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -4588,6 +4728,84 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@esm2cjs/execa": {
+      "version": "6.1.1-cjs.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/execa/-/execa-6.1.1-cjs.1.tgz",
+      "integrity": "sha512-FHxfnmuDIjY1VS/BLzDkL8EkbcFvi8s6x1nYQ1Nyu0An0n88EJcGhDBcRWLFwt3C3nT7xwI+MwHRH1TZcAFW2w==",
+      "dev": true,
+      "requires": {
+        "@esm2cjs/human-signals": "^3.0.1",
+        "@esm2cjs/is-stream": "^3.0.0",
+        "@esm2cjs/npm-run-path": "^5.1.1-cjs.0",
+        "@esm2cjs/onetime": "^6.0.1-cjs.0",
+        "@esm2cjs/strip-final-newline": "^3.0.1-cjs.0",
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "merge-stream": "^2.0.0",
+        "signal-exit": "^3.0.7"
+      }
+    },
+    "@esm2cjs/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-QZme4eF/PwTpeSbMB4AaWGQ4VSygzE30jI+Oas1NPTtZQAgcHwWVDOQpIW8FUmtzn5Q+2cS7AjnTzbtqtc5P6g==",
+      "dev": true
+    },
+    "@esm2cjs/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-qcBscHlJpZFOD5nnmMHkzOrq2xyvsp9fbVreQLS8x2LOs8N3CrNi3fqvFY0GVJR+YSOHscwhG9T5t4Ck7R7QGw==",
+      "dev": true
+    },
+    "@esm2cjs/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-LIIAjcpjLr4rcbYmRQ+eRu55Upy/MMB78seIlwqbnyiA+cTa1/pxWnJ1NHJQrw6tx2wMQmlYoJj+wf16NjWH6Q==",
+      "dev": true
+    },
+    "@esm2cjs/npm-run-path": {
+      "version": "5.1.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/npm-run-path/-/npm-run-path-5.1.1-cjs.0.tgz",
+      "integrity": "sha512-CWeAIyE8iNSCgP2ItPE8iPgS+lACqgH+MuFRaWOIl2T7hnHqPFfhAJJ/LcLJJ/RMIxNMeenjFMwc91HW7NWr1A==",
+      "dev": true,
+      "requires": {
+        "@esm2cjs/path-key": "^4.0.0"
+      }
+    },
+    "@esm2cjs/onetime": {
+      "version": "6.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/onetime/-/onetime-6.0.1-cjs.0.tgz",
+      "integrity": "sha512-MkZMZSxrSC/6yUuAw6Azc56XOgwHQQIsNDlO/zgFmOcycJBhRwRuc/gdYUUOFNZIh7y+f0JSIxkNdJPFvJ5W0w==",
+      "dev": true,
+      "requires": {
+        "@esm2cjs/mimic-fn": "^4.0.0"
+      }
+    },
+    "@esm2cjs/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-t2YIlQHsgMy8vyC8oSxIyGuhc99KPjjPI808IENcvWaKWlFEANu8VEO3tMN9jqaqJQp/WpLx+SLqm3vC6Ve9pQ==",
+      "requires": {
+        "@esm2cjs/yocto-queue": "^1.0.0"
+      }
+    },
+    "@esm2cjs/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-fKzZ3uIIP4j+7WfyG0MEkomGHL0hUXWCx1kY2Zct3GTdl4pyY+3k5lCUxjgdDa2Ld1BCjMNorXnRHiBP6jW6CQ==",
+      "dev": true
+    },
+    "@esm2cjs/strip-final-newline": {
+      "version": "3.0.1-cjs.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/strip-final-newline/-/strip-final-newline-3.0.1-cjs.0.tgz",
+      "integrity": "sha512-o41riCGPiOEStayoikBCAqwa6igbv9L9rP+k5UCfQ24EJD/wGrdDs/KTNwkHG5JzDK3T60D5dMkWkLKEPy8gjA==",
+      "dev": true
+    },
+    "@esm2cjs/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@esm2cjs/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-bDqljAQBEJji4mZ4uuH27Zhr5OOoB6YWe/ccG8lt2ZTwZAeOAoS3wugsGQzVUZcxkBYonbXqi/1+rizbuU833A=="
     },
     "@google-cloud/common": {
       "version": "3.6.0",
@@ -5997,13 +6215,6 @@
         "onetime": "^5.1.2",
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        }
       }
     },
     "extend": {
@@ -6899,6 +7110,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -7166,6 +7378,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sinon": {
       "version": "14.0.0",
@@ -7615,7 +7832,8 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@alcalzone/release-script": "^3.5.9",
+    "@esm2cjs/execa": "^6.1.1-cjs.1",
     "@tsconfig/node12": "^1.0.11",
     "@types/ansi-colors": "^3.2.2",
     "@types/chai": "^4.3.1",
@@ -56,7 +57,6 @@
     "copyfiles": "^2.4.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "execa": "^5.1.1",
     "jsonschema": "^1.4.1",
     "mocha": "^10.0.0",
     "proxyquire": "^2.1.3",
@@ -67,6 +67,7 @@
     "ts-node": "^10.9.1"
   },
   "dependencies": {
+    "@esm2cjs/p-limit": "^4.0.0",
     "@iobroker/adapter-dev": "^1.0.0",
     "@typescript-eslint/parser": "^5.23.0",
     "alcalzone-shared": "^4.0.1",
@@ -77,7 +78,6 @@
     "eslint": "^8.20.0",
     "fs-extra": "^10.1.0",
     "json5": "^2.2.1",
-    "p-limit": "^3.1.0",
     "prettier": "^2.6.2",
     "semver": "^7.3.7",
     "typescript": "~4.6.4",

--- a/templates/package.json.ts
+++ b/templates/package.json.ts
@@ -1,5 +1,5 @@
+import pLimit from "@esm2cjs/p-limit";
 import * as JSON5 from "json5";
-import pLimit from "p-limit";
 import { licenses } from "../src/lib/core/licenses";
 import { getDefaultAnswer } from "../src/lib/core/questions";
 import type { TemplateFunction } from "../src/lib/createAdapter";

--- a/test/create-adapter.test.ts
+++ b/test/create-adapter.test.ts
@@ -1,8 +1,8 @@
 // Disable API requests while testing
 process.env.TESTING = "true";
 
+import { execaSync } from "@esm2cjs/execa";
 import axios from "axios";
-import * as execa from "execa";
 import * as fs from "fs-extra";
 import { validate as validateJSON } from "jsonschema";
 import * as path from "path";
@@ -56,7 +56,7 @@ async function generateBaselines(
 	// Include the npm package content in the baselines (only for full adapter tests)
 	if (!filterFilesPredicate && files.some((f) => f.name === "package.json")) {
 		const packageContent = JSON.parse(
-			execa.sync("npm", ["pack", "--dry-run", "--json"], {
+			execaSync("npm", ["pack", "--dry-run", "--json"], {
 				cwd: testDir,
 				encoding: "utf8",
 			}).stdout,


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
-   [x] Run the test suite with `npm test`
-   [ ] ~~If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes~~
-   [x] Ensure the project builds with `npm run build`
-   [ ] ~~If you added a required option, also add it to the template creation (`.github/create_templates.ts`)~~
-   [ ] ~~Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project~~
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
Most packages from maintainer sindresorhus are now pure ESM. We can't handle those easily, so this PR replaces them with copies that were automatically converted to be hybrid ESM/CommonJS variants.

closes https://github.com/ioBroker/create-adapter/pull/873
closes https://github.com/ioBroker/create-adapter/pull/802