### PR TITLE
fix: offer Prettier for JS too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * (UncleSamSwiss) Add support for JSON Config UI (#724)
 * (crycode-de) Fix `npm run check` for TS-React adapters · [Migration guide](docs/updates/20220608_check_ts_react.md)
 * (AlCalzone) Replace ESM-only dependencies (#943)
+* (AlCalzone) Fix: Offer `Prettier` for JS adapters too (#945)
 
 ## 2.1.1 (2022-04-01)
 * (UncleSamSwiss) Setting `eraseOnUpload` to `true` for React adapters (#886) · [Migration guide](docs/updates/20220301_erase_on_upload.md)

--- a/src/lib/core/questions.ts
+++ b/src/lib/core/questions.ts
@@ -638,6 +638,10 @@ export const questionGroups: QuestionGroup[] = [
 					{ message: "ESLint", hint: "(recommended)" },
 					{ message: "type checking", hint: "(recommended)" },
 					{
+						message: "Prettier",
+						hint: "(requires ESLint, enables automatic code formatting in VSCode)",
+					},
+					{
 						message: "devcontainer",
 						hint: "(Requires VSCode and Docker, starts a fresh ioBroker in a Docker container with only your adapter installed)",
 					},
@@ -648,6 +652,7 @@ export const questionGroups: QuestionGroup[] = [
 						ctx.hasDevDependency("typescript")
 							? "type checking"
 							: null,
+						ctx.hasDevDependency("prettier") ? "Prettier" : null,
 						(await ctx.directoryExists(".devcontainer"))
 							? "devcontainer"
 							: null,


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ ] ~~Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).~~
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [x] Ensure the project builds with `npm run build`
-   [ ] ~~If you added a required option, also add it to the template creation (`.github/create_templates.ts`)~~
-   [ ] ~~Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project~~
-   [ ] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
This PR fixes a bug where Prettier is not offered as a tool for JS adapters, although we did support it.

fixes: #942 