### PR TITLE
Fix incorrect statement inside main.js in legacy mode (#972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 	## __WORK IN PROGRESS__
 	(at the beginning of a new line )
 -->
+## __WORK IN PROGRESS__
+* (mcm1957) Fix incorrect statement inside main.js in lagacy mode (#972)
+
 ## 2.2.1 (2022-09-08)
 * (AlCalzone) Fix `lint` command for JS adapters · [Migration guide](docs/updates/20220908_fix_lint_command.md)
 * (Apollon77 & AlCalzone) Add disclaimer about use of names and logos to README (#957)

--- a/templates/main.js.ts
+++ b/templates/main.js.ts
@@ -105,7 +105,7 @@ async function main() {
 
 ${answers.connectionIndicator === "yes" ? `
 	// Reset the connection indicator during startup
-	await this.setStateAsync("info.connection", false, true);
+	await adapter.setStateAsync("info.connection", false, true);
 ` : ""}
 
 	// The adapters config (in the instance object everything under the attribute "native") is accessible via


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [ ok ] Provide a meaningful description to this PR or mention which issues this fixes.
-   [ n/a ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [ *FAILS* ] Run the test suite with `npm test`
-   [ n/a ] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [ ok ] Ensure the project builds with `npm run build`
-   [ n/a ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [ n/a ] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [ ok ] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
I've only change one word inside the template for main.js .
npm test is not running- I assume that some setup is missing at my system.

`
>E:\GitHub\mcm1957\create-adapter>npm run build
> @iobroker/create-adapter@2.2.1 prebuild
> npm run prebuild:cleanBuildDir && npm run linkTemplates && npm run prebuild:cacheLicenses
> @iobroker/create-adapter@2.2.1 prebuild:cleanBuildDir
> rimraf ./build
>Der Befehl "rimraf" ist entweder falsch geschrieben oder
>konnte nicht gefunden werden.`

Please review code difference and accept PR if you feel OK.
OR simply discard my PR. Don't have any problem if Issue #972 is change in some other way