### PR TITLE
Remove `common.title`

### DIFF
--- a/templates/io-package.json.ts
+++ b/templates/io-package.json.ts
@@ -20,7 +20,6 @@ export = (async answers => {
 
 	const languages = ["en", "de", "ru", "pt", "nl", "fr", "it", "es", "pl", "uk", "zh-cn"];
 
-	const title: string = answers.title || answers.adapterName;
 	const titleLang = JSON.stringify(
 		composeObject(await Promise.all(
 			languages.map(async lang => [lang, await translateText(title, lang)] as [string, string]),


### PR DESCRIPTION
`common.title` is declared as deprecated by the ioBroker Adapter Checker:

> [W171] "common.title" is deprecated in io-package.json

It shall be removed from the template for this reason.