### PR TITLE
Remove the `subscribe` start mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## __WORK IN PROGRESS__
 * (theknut) Make ioBroker types available in the test directory (#1091)
 * (theknut) Add `licenseInformation` field to `io-package.json` (#1092)
+* (AlCalzone) Remove the `subscribe` start mode (#1093)
 
 ## 2.6.1 (2024-01-15)
 * (AlCalzone) Fixed an issue with TypeScript tests caused by #1082 (fixes #1084)

--- a/src/lib/core/questions.ts
+++ b/src/lib/core/questions.ts
@@ -424,13 +424,9 @@ export const questionGroups: QuestionGroup[] = [
 						hint: dim.gray("(recommended for most adapters)"),
 						value: "daemon",
 					},
-					{
-						message: `when the ".alive" state is true`,
-						value: "subscribe",
-					},
 					{ message: "depending on a schedule", value: "schedule" },
 					{
-						message: "when the instance object changes",
+						message: "only once after changing the instance object",
 						value: "once",
 					},
 					{ message: "never", value: "none" },
@@ -1026,7 +1022,7 @@ export interface Answers {
 	gitCommit?: "yes" | "no";
 	defaultBranch?: "main" | "master";
 	dependabot?: "yes" | "no";
-	startMode?: "daemon" | "schedule" | "subscribe" | "once" | "none";
+	startMode?: "daemon" | "schedule" | "once" | "none";
 	scheduleStartOnChange?: "yes" | "no";
 	connectionIndicator?: "yes" | "no";
 	connectionType?: "cloud" | "local";


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [x] Ensure the project builds with `npm run build`
-   [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes - **no changes**
-   [ ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [ ] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
As discussed behind the scenes, this start mode doesn't really make sense nowadays, isn't documented anywhere and probably not even supported correctly.

fixes: #1088