### PR TITLE
Remove deprecated `title` and `main` fields from `io-package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 	(at the beginning of a new line)
 -->
 ## __WORK IN PROGRESS__
+* (AlCalzone) Remove deprecated `main` and `title` fields from `io-package.json` (#1115)
 * (AlCalzone) Remove deprecated license field from `io-package.json` (#1114)
 * (AlCalzone) Add Node.js 22 as a supported version, set 20 as the default choice (#1112)
 * (AlCalzone) Update CI workflows for the adapter creator (#1111)

--- a/templates/io-package.json.ts
+++ b/templates/io-package.json.ts
@@ -9,7 +9,6 @@ export = (async answers => {
 
 	const isAdapter = answers.features.indexOf("adapter") > -1;
 	const isWidget = answers.features.indexOf("vis") > -1;
-	const useTypeScript = answers.language === "TypeScript";
 	const useJsonConfig = answers.adminUi === "json";
 	const useAdminReact = answers.adminUi === "react";
 	const useTabReact = answers.tabReact === "yes";
@@ -80,7 +79,6 @@ export = (async answers => {
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "${title}",
 		"titleLang": ${titleLang},
 		"desc": ${descriptionLang},
 		"authors": [
@@ -90,7 +88,6 @@ export = (async answers => {
 		"license": "${licenseId}",
 		"licenseInformation": ${JSON.stringify(licenseInformation)},
 		"platform": "Javascript/Node.js",
-		"main": "${useTypeScript ? "build/" : ""}main.js",
 		"icon": "${getIconName(answers)}",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/${answers.authorGithub}/ioBroker.${answers.adapterName}/${defaultBranch}/admin/${getIconName(answers)}",

--- a/test/baselines/adapter_JS_JsonUI_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/io-package.json
+++ b/test/baselines/adapter_JS_JsonUI_ESLint_TypeChecking_Spaces_SingleQuotes_Apache-2.0/io-package.json
@@ -17,7 +17,6 @@
                 "zh-cn": "首次出版"
             }
         },
-        "title": "Is used to test the creator",
         "titleLang": {
             "en": "Is used to test the creator",
             "de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
             "license": "Apache-2.0"
         },
         "platform": "Javascript/Node.js",
-        "main": "main.js",
         "icon": "test-adapter.png",
         "enabled": true,
         "extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/adapter_JS_React/io-package.json
+++ b/test/baselines/adapter_JS_React/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/io-package.json
+++ b/test/baselines/adapter_TS_ESLint_Tabs_DoubleQuotes_MIT/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/adapter_TS_React/io-package.json
+++ b/test/baselines/adapter_TS_React/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/connectionIndicator_yes/io-package.json
+++ b/test/baselines/connectionIndicator_yes/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/connectionType/io-package.json
+++ b/test/baselines/connectionType/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/customAdapterSettings/io-package.json
+++ b/test/baselines/customAdapterSettings/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/description_empty_1/io-package.json
+++ b/test/baselines/description_empty_1/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/description_empty_2/io-package.json
+++ b/test/baselines/description_empty_2/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/description_valid/io-package.json
+++ b/test/baselines/description_valid/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/keywords/io-package.json
+++ b/test/baselines/keywords/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -60,7 +59,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/no_config/io-package.json
+++ b/test/baselines/no_config/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/startMode_schedule/io-package.json
+++ b/test/baselines/startMode_schedule/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/type_storage/io-package.json
+++ b/test/baselines/type_storage/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/type_visualization-icons/io-package.json
+++ b/test/baselines/type_visualization-icons/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "build/main.js",
 		"icon": "test-adapter.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-adapter/main/admin/test-adapter.png",

--- a/test/baselines/vis_Widget/io-package.json
+++ b/test/baselines/vis_Widget/io-package.json
@@ -17,7 +17,6 @@
 				"zh-cn": "首次出版"
 			}
 		},
-		"title": "Is used to test the creator",
 		"titleLang": {
 			"en": "Is used to test the creator",
 			"de": "Mock translation of 'Is used to test the creator' to 'de'",
@@ -59,7 +58,6 @@
 			"license": "MIT"
 		},
 		"platform": "Javascript/Node.js",
-		"main": "main.js",
 		"icon": "test-widget.png",
 		"enabled": true,
 		"extIcon": "https://raw.githubusercontent.com/AlCalzone/ioBroker.test-widget/main/admin/test-widget.png",


### PR DESCRIPTION
<!--
	Thanks for providing a PR!
	Please make sure you have completed the following checklist before submitting your PR
-->

**PR Checklist:**

-   [x] Provide a meaningful description to this PR or mention which issues this fixes.
-   [x] Ensure the project builds with `npm run build`
-   [ ] Add tests for your change. This includes negative tests (i.e. inputs that need to fail) as well as baseline tests (i.e. how should the directory structure look like?).
-   [x] Run the test suite with `npm test`
-   [x] If there are baseline changes, review them and make a separate commit for them with the comment "accept baselines" if they are desired changes
-   [ ] If you added a required option, also add it to the template creation (`.github/create_templates.ts`)
-   [ ] Add a detailed migration description to `docs/updates` explaining what the user needs to do when manually updating an existing project
-   [x] Add your changes to `CHANGELOG.md` (referencing the migration description and this PR or the issue you fixed)

**Description:**  
Fixes: https://github.com/ioBroker/create-adapter/issues/1101
